### PR TITLE
Raise requirements for Doctrine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
   "require": {
     "php": ">=5.5.0",
     "symfony/symfony": "~2.3|~3.0",
+    "doctrine/dbal": "~2.5",
     "doctrine/doctrine-bundle": "~1.4",
     "phpunit/phpunit": "~4.1"
   },


### PR DESCRIPTION
The class `Doctrine\DBAL\Driver\ExceptionConverterDriver` exists only since Doctrine 2.5