### PR TITLE
Add branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,10 @@
   },
   "autoload-dev": {
     "psr-4": { "Tests\\": "tests/" }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "2.0.x-dev"
+    }
   }
 }


### PR DESCRIPTION
This allows getting master without actually using `dev-master` as requirement