### PR TITLE
Support PHPUnit namespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: php
 
 php:
-  - '5.5'
-  - '5.6'
   - '7.0'
+  - '7.1'
 
 env:
   - SYMFONY_VERSION="2.3.*"
-  - SYMFONY_VERSION="2.7.*"
-  - SYMFONY_VERSION="3.0.*"
+  - SYMFONY_VERSION="2.8.*"
+  - SYMFONY_VERSION="3.2.*"
 
 install:
   - curl -s https://getcomposer.org/installer | php

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0",
+    "php": "^7.0",
     "symfony/symfony": "~2.3|~3.0",
     "doctrine/dbal": "~2.5",
     "doctrine/doctrine-bundle": "~1.4",
-    "phpunit/phpunit": "~4.1|~5.0|~6.0"
+    "phpunit/phpunit": "^6.0@dev"
   },
   "autoload": {
     "psr-4": {
@@ -27,7 +27,9 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "2.0.x-dev"
+      "dev-master": "2.1.x-dev"
     }
-  }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitStaticDbConnectionListener.php
+++ b/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitStaticDbConnectionListener.php
@@ -3,30 +3,33 @@
 namespace DAMA\DoctrineTestBundle\PHPUnit;
 
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
+use PHPUnit\Framework\BaseTestListener;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestSuite;
 
-class PHPUnitStaticDbConnectionListener extends \PHPUnit_Framework_BaseTestListener
+class PHPUnitStaticDbConnectionListener extends BaseTestListener
 {
     /**
-     * @param \PHPUnit_Framework_Test $test
+     * @param Test $test
      */
-    public function startTest(\PHPUnit_Framework_Test $test)
+    public function startTest(Test $test)
     {
         StaticDriver::beginTransaction();
     }
 
     /**
-     * @param \PHPUnit_Framework_Test $test
-     * @param $time
+     * @param Test $test
+     * @param int  $time
      */
-    public function endTest(\PHPUnit_Framework_Test $test, $time)
+    public function endTest(Test $test, $time)
     {
         StaticDriver::rollBack();
     }
 
     /**
-     * @param \PHPUnit_Framework_TestSuite $suite
+     * @param TestSuite $suite
      */
-    public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
+    public function startTestSuite(TestSuite $suite)
     {
         StaticDriver::setKeepStaticConnections(true);
     }

--- a/tests/DAMA/DoctrineTestBundle/DependencyInjection/DAMADoctrineTestExtensionTest.php
+++ b/tests/DAMA/DoctrineTestBundle/DependencyInjection/DAMADoctrineTestExtensionTest.php
@@ -3,9 +3,10 @@
 namespace Tests\DAMA\DoctrineTestBundle\DependencyInjection;
 
 use DAMA\DoctrineTestBundle\DependencyInjection\DAMADoctrineTestExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class DAMADoctrineTestExtensionTest extends \PHPUnit_Framework_TestCase
+class DAMADoctrineTestExtensionTest extends TestCase
 {
     /**
      * @dataProvider loadDataProvider

--- a/tests/DAMA/DoctrineTestBundle/DependencyInjection/DoctrineTestCompilerPassTest.php
+++ b/tests/DAMA/DoctrineTestBundle/DependencyInjection/DoctrineTestCompilerPassTest.php
@@ -5,10 +5,11 @@ namespace tests\DAMA\DoctrineTestBundle\DependencyInjection;
 use DAMA\DoctrineTestBundle\DependencyInjection\DAMADoctrineTestExtension;
 use DAMA\DoctrineTestBundle\DependencyInjection\DoctrineTestCompilerPass;
 use DAMA\DoctrineTestBundle\Doctrine\Cache\StaticArrayCache;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-class DoctrineTestCompilerPassTest extends \PHPUnit_Framework_TestCase
+class DoctrineTestCompilerPassTest extends TestCase
 {
     /**
      * @dataProvider processDataProvider
@@ -17,7 +18,7 @@ class DoctrineTestCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcess(array $processedConfig)
     {
-        $extension = $this->getMock(DAMADoctrineTestExtension::class);
+        $extension = $this->createMock(DAMADoctrineTestExtension::class);
         $extension
             ->expects($this->once())
             ->method('getProcessedConfig')

--- a/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactoryTest.php
+++ b/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactoryTest.php
@@ -4,8 +4,9 @@ namespace Tests\DAMA\DoctrineTestBundle\Doctrine\DBAL;
 
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticConnectionFactory;
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
+use PHPUnit\Framework\TestCase;
 
-class StaticConnectionFactoryTest extends \PHPUnit_Framework_TestCase
+class StaticConnectionFactoryTest extends TestCase
 {
     /**
      * @dataProvider createConnectionDataProvider

--- a/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
+++ b/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
@@ -4,8 +4,9 @@ namespace Tests\DAMA\DoctrineTestBundle\Doctrine\DBAL;
 
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticConnection;
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
+use PHPUnit\Framework\TestCase;
 
-class StaticDriverTest extends \PHPUnit_Framework_TestCase
+class StaticDriverTest extends TestCase
 {
     public function testConnect()
     {


### PR DESCRIPTION
Since newest PHPUnit switched to namespaces (about time!), we need to follow such change.
This is, of course, a BC break with previous versions.
My advice is, after merging this PR, to create a new branch "1.x" to support legacy versions and to keep dev-master up to date with PHPUnit (so, requiring '^6.0' only). Then, tag a new release next month (when PHPUnit will be stable). In meantime, using dev-master here will be requiring using dev-master on PHPUnit as well.