### PR TITLE
fix StaticDriver usage (#23)

### DIFF
--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
@@ -21,22 +21,13 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     private static $keepStaticConnections = false;
 
     /**
-     * @var string
-     */
-    private static $underlyingDriverClass;
-
-    /**
      * @var Driver
      */
     private $underlyingDriver;
 
-    public function __construct()
+    public function __construct(Driver $underlyingDriver)
     {
-        if (self::$underlyingDriverClass === null) {
-            throw new \Exception('Cannot instantiate without setting underlying Driver class');
-        }
-
-        $this->underlyingDriver = new self::$underlyingDriverClass();
+        $this->underlyingDriver = $underlyingDriver;
     }
 
     /**
@@ -128,14 +119,6 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     public static function isKeepStaticConnections()
     {
         return self::$keepStaticConnections;
-    }
-
-    /**
-     * @param string $underlyingDriverClass
-     */
-    public static function setUnderlyingDriverClass($underlyingDriverClass)
-    {
-        self::$underlyingDriverClass = $underlyingDriverClass;
     }
 
     public static function beginTransaction()

--- a/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
+++ b/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
@@ -9,10 +9,9 @@ class StaticDriverTest extends \PHPUnit_Framework_TestCase
 {
     public function testConnect()
     {
-        $driver = new StaticDriver();
+        $driver = new StaticDriver(new MockDriver());
 
         $driver::setKeepStaticConnections(true);
-        $driver::setUnderlyingDriverClass(MockDriver::class);
 
         $connection1 = $driver->connect(['database_name' => 1], 'user1', 'pw1');
         $connection2 = $driver->connect(['database_name' => 2], 'user1', 'pw2');
@@ -20,7 +19,7 @@ class StaticDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(StaticConnection::class, $connection1);
         $this->assertNotSame($connection1->getWrappedConnection(), $connection2->getWrappedConnection());
 
-        $driver = new StaticDriver();
+        $driver = new StaticDriver(new MockDriver());
 
         $connectionNew1 = $driver->connect(['database_name' => 1], 'user1', 'pw1');
         $connectionNew2 = $driver->connect(['database_name' => 2], 'user1', 'pw2');


### PR DESCRIPTION
* fix StaticDriver usage

In some scenarios where the doctrine dbal connection was configured using 'url: ...' the StaticDriver was not used because Doctrine ignores the 'driverClass' param in that case :(

See https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/DriverManager.php#L403

* keep test suite compatible with phpunit 4.x