### PR TITLE
fix: re-use existing platform object for connections

### DIFF
--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactory.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactory.php
@@ -28,7 +28,7 @@ class StaticConnectionFactory extends ConnectionFactory
         /** @var Connection $connection */
         $connection = new $connectionWrapperClass(
             $connectionOriginalDriver->getParams(),
-            new StaticDriver($connectionOriginalDriver->getDriver()),
+            new StaticDriver($connectionOriginalDriver->getDriver(), $connectionOriginalDriver->getDatabasePlatform()),
             $connectionOriginalDriver->getConfiguration(),
             $connectionOriginalDriver->getEventManager()
         );

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\DriverException;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 
 class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlatformDriver
@@ -25,9 +26,15 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
      */
     private $underlyingDriver;
 
-    public function __construct(Driver $underlyingDriver)
+    /**
+     * @var AbstractPlatform
+     */
+    private $platform;
+
+    public function __construct(Driver $underlyingDriver, AbstractPlatform $platform)
     {
         $this->underlyingDriver = $underlyingDriver;
+        $this->platform = $platform;
     }
 
     /**
@@ -54,7 +61,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
      */
     public function getDatabasePlatform()
     {
-        return $this->underlyingDriver->getDatabasePlatform();
+        return $this->platform;
     }
 
     /**
@@ -98,11 +105,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
      */
     public function createDatabasePlatformForVersion($version)
     {
-        if ($this->underlyingDriver instanceof VersionAwarePlatformDriver) {
-            return $this->underlyingDriver->createDatabasePlatformForVersion($version);
-        }
-
-        return $this->getDatabasePlatform();
+        return $this->platform;
     }
 
     /**

--- a/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
+++ b/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
@@ -4,12 +4,31 @@ namespace Tests\DAMA\DoctrineTestBundle\Doctrine\DBAL;
 
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticConnection;
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class StaticDriverTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var AbstractPlatform|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $platform;
+
+    public function setUp()
+    {
+        $this->platform = $this->getMock(AbstractPlatform::class);
+    }
+
+    public function testReturnCorrectPlatform()
+    {
+        $driver = new StaticDriver(new MockDriver(), $this->platform);
+
+        $this->assertSame($this->platform, $driver->getDatabasePlatform());
+        $this->assertSame($this->platform, $driver->createDatabasePlatformForVersion(1));
+    }
+
     public function testConnect()
     {
-        $driver = new StaticDriver(new MockDriver());
+        $driver = new StaticDriver(new MockDriver(), $this->platform);
 
         $driver::setKeepStaticConnections(true);
 
@@ -19,7 +38,7 @@ class StaticDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(StaticConnection::class, $connection1);
         $this->assertNotSame($connection1->getWrappedConnection(), $connection2->getWrappedConnection());
 
-        $driver = new StaticDriver(new MockDriver());
+        $driver = new StaticDriver(new MockDriver(), $this->platform);
 
         $connectionNew1 = $driver->connect(['database_name' => 1], 'user1', 'pw1');
         $connectionNew2 = $driver->connect(['database_name' => 2], 'user1', 'pw2');


### PR DESCRIPTION
In some cases when working with the schema tool (for example creating a diff) in the testing environment (so when the bundle is loaded) the mapping types information was lost due to the fact that we did not re-use the platform created originally by the factory using the original connection.

Now we are simply re-using the platform instance to keep all the mapping information etc.