### PR TITLE
README: simplify install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,9 @@ It also includes a `StaticArrayCache` that will be automatically configured as m
 
 1. install via composer
 
-    If you are using PHPUnit < 6:    
     ```sh
-    composer require --dev dama/doctrine-test-bundle "^1.0"
+    composer require --dev dama/doctrine-test-bundle
     ```
-    
-    If you are using PHPUnit >= 6:
-     ```sh
-    composer require --dev dama/doctrine-test-bundle "^2.0"
-    ```
-    
 
 2. Enable the bundle for your test environment in your `AppKernel.php`
 


### PR DESCRIPTION
Composer will actually pick the right version based on used PHPUnit version.
And also the one most up to date, compared to old readme text.