### PR TITLE
only require symfony/framework-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "symfony/symfony": "~2.3|~3.0",
+    "symfony/framework-bundle": "~2.3|~3.0",
     "doctrine/dbal": "~2.5",
     "doctrine/doctrine-bundle": "~1.4"
   },


### PR DESCRIPTION
Dependency on `symfony/symfony` is unnecessary so require only `symfony/framework-bundle`. 