### PR TITLE
Improve Travis build and collect test coverage

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,3 @@
+tools:
+  external_code_coverage:
+    runs: 9 # (PHP 5.6 + PHP 7.0 + PHP 7.1) * 3 Symfony versions

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,0 @@
-tools:
-  external_code_coverage:
-    runs: 9 # (PHP 5.6 + PHP 7.0 + PHP 7.1) * 3 Symfony versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: php
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 php:
   - '5.6'
@@ -11,7 +14,11 @@ env:
   - SYMFONY_VERSION="3.3.*"
 
 install:
-  - curl -s https://getcomposer.org/installer | php
-  - php composer.phar require symfony/symfony:${SYMFONY_VERSION}
+  - phpenv config-rm xdebug.ini || echo "xDebug not disabled"
+  - composer require symfony/symfony:${SYMFONY_VERSION}
 
-script: vendor/bin/phpunit -c tests/ tests/
+script: phpdbg -qrr vendor/bin/phpunit -c tests/ tests/ --coverage-clover ./build/logs/clover.xml
+
+after_success:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover ./build/logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,22 @@ env:
   - SYMFONY_VERSION="3.2.*"
   - SYMFONY_VERSION="3.3.*"
 
+matrix:
+  include:
+    - php: 7.1
+      env: 
+      - TEST_COVERAGE=true
+      - SYMFONY_VERSION="3.3.*"
+   - php: 7.2
+      env: 
+      - SYMFONY_VERSION="3.3.*"
+
 install:
   - phpenv config-rm xdebug.ini || echo "xDebug not disabled"
   - composer require symfony/symfony:${SYMFONY_VERSION}
 
-script: phpdbg -qrr vendor/bin/phpunit -c tests/ tests/ --coverage-clover ./build/logs/clover.xml
+script: 
+  - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr vendor/bin/phpunit -c tests/ tests/ --coverage-clover ./build/logs/clover.xml; else vendor/bin/phpunit -c tests/ tests/; fi
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,12 @@ matrix:
   include:
     - php: 7.1
       env: 
-      - TEST_COVERAGE=true
-      - SYMFONY_VERSION="3.3.*"
-   - php: 7.2
-      env: 
-      - SYMFONY_VERSION="3.3.*"
+        - TEST_COVERAGE=true
+    - php: 7.2
 
 install:
   - phpenv config-rm xdebug.ini || echo "xDebug not disabled"
-  - composer require symfony/symfony:${SYMFONY_VERSION}
+  - composer require symfony/symfony:${SYMFONY_VERSION:-"3.3.*"}
 
 script: 
   - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr vendor/bin/phpunit -c tests/ tests/ --coverage-clover ./build/logs/clover.xml; else vendor/bin/phpunit -c tests/ tests/; fi

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 [![PHP Version](https://img.shields.io/badge/php-%5E5.5-blue.svg)](https://img.shields.io/badge/php-%5E5.5-blue.svg)
 [![Stable release][Last stable image]][Packagist link]
 [![Unstable release][Last unstable image]][Packagist link]
+
 [![Build status][Master build image]][Master build link]
+[![Coverage Status][Master coverage image]][Master scrutinizer link]
+[![Scrutinizer][Master scrutinizer image]][Master scrutinizer link]
 
 ### What is it? 
 
@@ -72,6 +75,9 @@ dama_doctrine_test:
 [Last stable image]: https://poser.pugx.org/dama/doctrine-test-bundle/version.svg
 [Last unstable image]: https://poser.pugx.org/dama/doctrine-test-bundle/v/unstable.svg
 [Master build image]: https://travis-ci.org/dmaicher/doctrine-test-bundle.svg
+[Master scrutinizer image]: https://scrutinizer-ci.com/g/dmaicher/doctrine-test-bundle/badges/quality-score.png?b=master
+[Master coverage image]: https://scrutinizer-ci.com/g/dmaicher/doctrine-test-bundle/badges/coverage.png?b=master
 
 [Packagist link]: https://packagist.org/packages/dama/doctrine-test-bundle
 [Master build link]: https://travis-ci.org/dmaicher/doctrine-test-bundle
+[Master scrutinizer link]: https://scrutinizer-ci.com/g/dmaicher/doctrine-test-bundle/?branch=master


### PR DESCRIPTION
This PR follows #35; Scrutinizer has been enabled on this repo, now we can collect the test coverage.

I've also added a few improvements:
 * cache Composer's downloads between builds
 * skip download of Composer: it's already self-updated in the build by Travis
 * disable xDebug if possible (not possible under 7.2 if we want to add it)
 * use PHPDBG to collect the coverage, which is faster