### PR TITLE
Allow PHPUnit 6; fix PHPUnit configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - composer require symfony/symfony:${SYMFONY_VERSION:-"3.3.*"}
 
 script: 
-  - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr vendor/bin/phpunit -c tests/ tests/ --coverage-clover ./build/logs/clover.xml; else vendor/bin/phpunit -c tests/ tests/; fi
+  - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr vendor/bin/phpunit -c tests/ --coverage-clover ./build/logs/clover.xml; else vendor/bin/phpunit -c tests/ tests/; fi
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ script:
   - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr vendor/bin/phpunit -c tests/ --coverage-clover ./build/logs/clover.xml; else vendor/bin/phpunit -c tests/ tests/; fi
 
 after_success:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover ./build/logs/clover.xml
+  - if [[ $TEST_COVERAGE ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [[ $TEST_COVERAGE ]]; then php ocular.phar code-coverage:upload --format=php-clover ./build/logs/clover.xml; fi

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "doctrine/doctrine-bundle": "~1.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.0"
+    "phpunit/phpunit": "^5.4.4|~6.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,13 +1,19 @@
-<phpunit bootstrap="../vendor/autoload.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.2/phpunit.xsd"
+         bootstrap="../vendor/autoload.php" 
+         colors="true">
     <testsuites>
         <testsuite name="DAMADoctrineTestBundle test suite">
-            <directory suffix="Test.php">./src</directory>
+            <directory>../tests</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
+            <directory suffix=".php">../src</directory>
+            <exclude>
+                <file>../src/DAMA/DoctrineTestBundle/PHPUnit/LegacyPHPUnitListener.php</file>
+            </exclude>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
This follows #36 and #38. Sorry to have took so long to make it work, but third time's a charm! :smile: 

I allowed PHPUnit 6 in the composer.json, and fixed the PHPUnit config, which was the root of all problems. I had to exclude the `LegacyPHPUnitListener` from the coverage or PHPUnit would explode for due to interface incopatibility (a nagging thing on which I wrote about on [this blog post](https://engineering.facile.it/blog/eng/phpunit-upgrade-namespace/)).