### PR TITLE
Added phpstan to do static code analysis + fixed found bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-vendor
 composer.lock
+composer.phar
+phpstan.phar
 tests/Functional/cache
 tests/Functional/logs
 tests/Functional/parameters.yml
+vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
   - cp tests/Functional/parameters.yml.dist tests/Functional/parameters.yml
   - rm -rf tests/Functional/cache
   - if [[ $TEST_COVERAGE ]]; then phpdbg -qrr vendor/bin/phpunit -c tests/ --coverage-clover ./build/logs/clover.xml; else vendor/bin/phpunit -c tests/ tests/; fi
+  - make phpstan
 
 after_success:
   - if [[ $TEST_COVERAGE ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi

--- a/makefile
+++ b/makefile
@@ -1,9 +1,20 @@
-init_composer:
+SHELL = /bin/bash
+
+composer.phar:
 	curl -s https://getcomposer.org/installer | php
 	php composer.phar install --prefer-dist -o --dev
 
+.PHONY: test
 test:
 	vendor/bin/phpunit -c tests/ tests/
 
-build: init_composer test
+.PHONY: phpstan
+phpstan: phpstan.phar
+	# Run PHPStan only for PHP version >=7.0
+	php -r 'exit(PHP_VERSION_ID >= 70000 ? 1 : 0);' || ./phpstan.phar analyse -c phpstan.neon -a vendor/autoload.php -l 7 src
 
+phpstan.phar:
+	wget https://raw.githubusercontent.com/phpstan/phpstan-shim/0.9.1/phpstan.phar && chmod 777 phpstan.phar
+
+.PHONY: build
+build: composer.phar test phpstan

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    excludes_analyse:
+        - %rootDir%/../src/DAMA/DoctrineTestBundle/DependencyInjection/Configuration.php
+        - %rootDir%/../src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitListener.php

--- a/src/DAMA/DoctrineTestBundle/Doctrine/Cache/StaticArrayCache.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/Cache/StaticArrayCache.php
@@ -63,6 +63,6 @@ class StaticArrayCache extends CacheProvider
      */
     protected function doGetStats()
     {
-        return;
+        return null;
     }
 }

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
@@ -3,6 +3,7 @@
 namespace DAMA\DoctrineTestBundle\Doctrine\DBAL;
 
 use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\DriverException;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
@@ -97,7 +98,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
             return $this->underlyingDriver->convertException($message, $exception);
         }
 
-        return $exception;
+        return new Exception\DriverException($message, $exception);
     }
 
     /**
@@ -109,7 +110,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     }
 
     /**
-     * @param $keepStaticConnections bool
+     * @param bool $keepStaticConnections
      */
     public static function setKeepStaticConnections($keepStaticConnections)
     {


### PR DESCRIPTION
Hi David, thanks for amazing repo. I though I'll try out phpstan on it and found few minor bugs.

Added phpstan to do static code analysis + fixed found bugs:

* Set up PHPStan to run automatically via make
* Updated makefile to download composer.phar only once
* Fixed return value that should be null instead of void
* Fixed exception returned that should be concrete exception and not the interface provided by Doctrine.

