### PR TITLE
Don't exclude composer.json from git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 .gitattributes export-ignore
 .gitignore     export-ignore
 .travis.yml    export-ignore
-composer.json  export-ignore
 makefile       export-ignore
 README.md      export-ignore
 tests/         export-ignore


### PR DESCRIPTION
It's needed for some CI tools.

See also: https://github.com/maglnet/ComposerRequireChecker/issues/55

Would you mind to push a release after the merge? Thanks!