### PR TITLE
added support for PHPUnit 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tests/Functional/cache
 tests/Functional/logs
 tests/Functional/parameters.yml
 vendor
+.idea

--- a/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitListener.php
+++ b/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitListener.php
@@ -5,20 +5,39 @@ namespace DAMA\DoctrineTestBundle\PHPUnit;
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
 
 if (class_exists('\PHPUnit\Framework\BaseTestListener')) {
-    // PHPUnit 6
-    class PHPUnitListener extends \PHPUnit\Framework\BaseTestListener
-    {
-        public function startTest(\PHPUnit\Framework\Test $test)
+    if (interface_exists('\PHPUnit_Framework_Test')) {
+        // PHPUnit 5
+        class PHPUnitListener extends \PHPUnit\Framework\BaseTestListener
         {
-            StaticDriver::beginTransaction();
+            public function startTest(\PHPUnit_Framework_Test $test)
+            {
+                StaticDriver::beginTransaction();
+            }
+            public function endTest(\PHPUnit_Framework_Test $test, $time)
+            {
+                StaticDriver::rollBack();
+            }
+            public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
+            {
+                StaticDriver::setKeepStaticConnections(true);
+            }
         }
-        public function endTest(\PHPUnit\Framework\Test $test, $time)
+    } else {
+        // PHPUnit 6
+        class PHPUnitListener extends \PHPUnit\Framework\BaseTestListener
         {
-            StaticDriver::rollBack();
-        }
-        public function startTestSuite(\PHPUnit\Framework\TestSuite $suite)
-        {
-            StaticDriver::setKeepStaticConnections(true);
+            public function startTest(\PHPUnit\Framework\Test $test)
+            {
+                StaticDriver::beginTransaction();
+            }
+            public function endTest(\PHPUnit\Framework\Test $test, $time)
+            {
+                StaticDriver::rollBack();
+            }
+            public function startTestSuite(\PHPUnit\Framework\TestSuite $suite)
+            {
+                StaticDriver::setKeepStaticConnections(true);
+            }
         }
     }
 } elseif (trait_exists('\PHPUnit\Framework\TestListenerDefaultImplementation')) {


### PR DESCRIPTION
Using symfony 4 with phpunit bridge it seems my version of PHPUnit is 5.7.xx. So, of course, it made this bundle unusable. I fixed the Listener as to detect PHPUnit 5 and provide a listener that satisfies this version's interface :)