### PR TITLE
Add return types

### DIFF
--- a/src/DAMA/DoctrineTestBundle/DAMADoctrineTestBundle.php
+++ b/src/DAMA/DoctrineTestBundle/DAMADoctrineTestBundle.php
@@ -11,7 +11,7 @@ class DAMADoctrineTestBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
         $container->addCompilerPass(new DoctrineTestCompilerPass());

--- a/src/DAMA/DoctrineTestBundle/DependencyInjection/Configuration.php
+++ b/src/DAMA/DoctrineTestBundle/DependencyInjection/Configuration.php
@@ -11,10 +11,7 @@ class Configuration implements ConfigurationInterface
     const STATIC_META_CACHE = 'enable_static_meta_data_cache';
     const STATIC_QUERY_CACHE = 'enable_static_query_cache';
 
-    /**
-     * @return TreeBuilder
-     */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('dama_doctrine_test');
 

--- a/src/DAMA/DoctrineTestBundle/DependencyInjection/DAMADoctrineTestExtension.php
+++ b/src/DAMA/DoctrineTestBundle/DependencyInjection/DAMADoctrineTestExtension.php
@@ -12,16 +12,13 @@ class DAMADoctrineTestExtension extends Extension
      */
     private $processedConfig;
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $this->processedConfig = $this->processConfiguration($configuration, $configs);
     }
 
-    /**
-     * @return array
-     */
-    public function getProcessedConfig()
+    public function getProcessedConfig(): array
     {
         return $this->processedConfig;
     }

--- a/src/DAMA/DoctrineTestBundle/DependencyInjection/DoctrineTestCompilerPass.php
+++ b/src/DAMA/DoctrineTestBundle/DependencyInjection/DoctrineTestCompilerPass.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class DoctrineTestCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         /** @var DAMADoctrineTestExtension $extension */
         $extension = $container->getExtension('dama_doctrine_test');

--- a/src/DAMA/DoctrineTestBundle/Doctrine/Cache/StaticArrayCache.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/Cache/StaticArrayCache.php
@@ -22,7 +22,7 @@ class StaticArrayCache extends CacheProvider
     /**
      * {@inheritdoc}
      */
-    protected function doContains($id)
+    protected function doContains($id): bool
     {
         // isset() is required for performance optimizations, to avoid unnecessary function calls to array_key_exists.
         return isset(self::$data[$id]) || array_key_exists($id, self::$data);
@@ -31,7 +31,7 @@ class StaticArrayCache extends CacheProvider
     /**
      * {@inheritdoc}
      */
-    protected function doSave($id, $data, $lifeTime = 0)
+    protected function doSave($id, $data, $lifeTime = 0): bool
     {
         self::$data[$id] = $data;
 
@@ -41,7 +41,7 @@ class StaticArrayCache extends CacheProvider
     /**
      * {@inheritdoc}
      */
-    protected function doDelete($id)
+    protected function doDelete($id): bool
     {
         unset(self::$data[$id]);
 
@@ -51,7 +51,7 @@ class StaticArrayCache extends CacheProvider
     /**
      * {@inheritdoc}
      */
-    protected function doFlush()
+    protected function doFlush(): bool
     {
         self::$data = [];
 
@@ -61,7 +61,7 @@ class StaticArrayCache extends CacheProvider
     /**
      * {@inheritdoc}
      */
-    protected function doGetStats()
+    protected function doGetStats(): ?array
     {
         return null;
     }

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnection.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnection.php
@@ -109,9 +109,6 @@ class StaticConnection implements Connection
         return $this->connection->errorInfo();
     }
 
-    /**
-     * @return Connection
-     */
     public function getWrappedConnection(): Connection
     {
         return $this->connection;

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnection.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnection.php
@@ -3,7 +3,7 @@
 namespace DAMA\DoctrineTestBundle\Doctrine\DBAL;
 
 use Doctrine\DBAL\Driver\Connection;
-use Doctrine\DBAL\Driver\PDOStatement;
+use Doctrine\DBAL\Driver\Statement;
 
 /**
  * Wraps a real connection and just skips the first call to beginTransaction as a transaction is already started on the underlying connection.
@@ -28,7 +28,7 @@ class StaticConnection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function prepare($prepareString): PDOStatement
+    public function prepare($prepareString): Statement
     {
         return $this->connection->prepare($prepareString);
     }
@@ -36,7 +36,7 @@ class StaticConnection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function query(): PDOStatement
+    public function query(): Statement
     {
         return call_user_func_array([$this->connection, 'query'], func_get_args());
     }

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnection.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnection.php
@@ -3,6 +3,7 @@
 namespace DAMA\DoctrineTestBundle\Doctrine\DBAL;
 
 use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\PDOStatement;
 
 /**
  * Wraps a real connection and just skips the first call to beginTransaction as a transaction is already started on the underlying connection.
@@ -27,7 +28,7 @@ class StaticConnection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function prepare($prepareString)
+    public function prepare($prepareString): PDOStatement
     {
         return $this->connection->prepare($prepareString);
     }
@@ -35,7 +36,7 @@ class StaticConnection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function query()
+    public function query(): PDOStatement
     {
         return call_user_func_array([$this->connection, 'query'], func_get_args());
     }
@@ -51,7 +52,7 @@ class StaticConnection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function exec($statement)
+    public function exec($statement): int
     {
         return $this->connection->exec($statement);
     }
@@ -59,7 +60,7 @@ class StaticConnection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function lastInsertId($name = null)
+    public function lastInsertId($name = null): string
     {
         return $this->connection->lastInsertId($name);
     }
@@ -67,7 +68,7 @@ class StaticConnection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         if ($this->transactionStarted) {
             return $this->connection->beginTransaction();
@@ -79,7 +80,7 @@ class StaticConnection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function commit()
+    public function commit(): bool
     {
         return $this->connection->commit();
     }
@@ -87,7 +88,7 @@ class StaticConnection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function rollBack()
+    public function rollBack(): bool
     {
         return $this->connection->rollBack();
     }
@@ -95,7 +96,7 @@ class StaticConnection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function errorCode()
+    public function errorCode(): ?string
     {
         return $this->connection->errorCode();
     }
@@ -103,7 +104,7 @@ class StaticConnection implements Connection
     /**
      * {@inheritdoc}
      */
-    public function errorInfo()
+    public function errorInfo(): array
     {
         return $this->connection->errorInfo();
     }
@@ -111,7 +112,7 @@ class StaticConnection implements Connection
     /**
      * @return Connection
      */
-    public function getWrappedConnection()
+    public function getWrappedConnection(): Connection
     {
         return $this->connection;
     }

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactory.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactory.php
@@ -20,12 +20,6 @@ class StaticConnectionFactory extends ConnectionFactory
         $this->decoratedFactory = $decoratedFactory;
     }
 
-    /**
-     * @param Configuration $config
-     * @param EventManager  $eventManager
-     *
-     * @return Connection
-     */
     public function createConnection(array $params, Configuration $config = null, EventManager $eventManager = null, array $mappingTypes = []): Connection
     {
         // create the original connection to get the used wrapper class + driver

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactory.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactory.php
@@ -24,9 +24,9 @@ class StaticConnectionFactory extends ConnectionFactory
      * @param Configuration $config
      * @param EventManager  $eventManager
      *
-     * @return \Doctrine\DBAL\Connection
+     * @return Connection
      */
-    public function createConnection(array $params, Configuration $config = null, EventManager $eventManager = null, array $mappingTypes = [])
+    public function createConnection(array $params, Configuration $config = null, EventManager $eventManager = null, array $mappingTypes = []): Connection
     {
         // create the original connection to get the used wrapper class + driver
         $connectionOriginalDriver = $this->decoratedFactory->createConnection($params, $config, $eventManager, $mappingTypes);

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
@@ -41,7 +41,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = []): Connection
     {
         if (self::$keepStaticConnections) {
             $key = sha1(serialize($params).$username.$password);
@@ -60,7 +60,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     /**
      * {@inheritdoc}
      */
-    public function getDatabasePlatform()
+    public function getDatabasePlatform(): AbstractPlatform
     {
         return $this->platform;
     }
@@ -68,7 +68,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     /**
      * {@inheritdoc}
      */
-    public function getSchemaManager(\Doctrine\DBAL\Connection $conn)
+    public function getSchemaManager(\Doctrine\DBAL\Connection $conn): AbstractSchemaManager
     {
         return $this->underlyingDriver->getSchemaManager($conn);
     }
@@ -76,7 +76,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->underlyingDriver->getName();
     }
@@ -84,7 +84,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     /**
      * {@inheritdoc}
      */
-    public function getDatabase(\Doctrine\DBAL\Connection $conn)
+    public function getDatabase(\Doctrine\DBAL\Connection $conn): string
     {
         return $this->underlyingDriver->getDatabase($conn);
     }
@@ -92,7 +92,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     /**
      * {@inheritdoc}
      */
-    public function convertException($message, DriverException $exception)
+    public function convertException($message, DriverException $exception): Exception\DriverException
     {
         if ($this->underlyingDriver instanceof ExceptionConverterDriver) {
             return $this->underlyingDriver->convertException($message, $exception);
@@ -104,7 +104,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     /**
      * {@inheritdoc}
      */
-    public function createDatabasePlatformForVersion($version)
+    public function createDatabasePlatformForVersion($version): AbstractPlatform
     {
         return $this->platform;
     }
@@ -112,7 +112,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     /**
      * @param bool $keepStaticConnections
      */
-    public static function setKeepStaticConnections($keepStaticConnections)
+    public static function setKeepStaticConnections($keepStaticConnections): void
     {
         self::$keepStaticConnections = $keepStaticConnections;
     }
@@ -120,12 +120,12 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     /**
      * @return bool
      */
-    public static function isKeepStaticConnections()
+    public static function isKeepStaticConnections(): bool
     {
         return self::$keepStaticConnections;
     }
 
-    public static function beginTransaction()
+    public static function beginTransaction(): void
     {
         foreach (self::$connections as $con) {
             try {
@@ -136,14 +136,14 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
         }
     }
 
-    public static function rollBack()
+    public static function rollBack(): void
     {
         foreach (self::$connections as $con) {
             $con->rollBack();
         }
     }
 
-    public static function commit()
+    public static function commit(): void
     {
         foreach (self::$connections as $con) {
             $con->commit();

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\DriverException;
 use Doctrine\DBAL\Driver\ExceptionConverterDriver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 
 class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlatformDriver

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
@@ -118,9 +118,6 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
         self::$keepStaticConnections = $keepStaticConnections;
     }
 
-    /**
-     * @return bool
-     */
     public static function isKeepStaticConnections(): bool
     {
         return self::$keepStaticConnections;

--- a/tests/DAMA/DoctrineTestBundle/DependencyInjection/DAMADoctrineTestExtensionTest.php
+++ b/tests/DAMA/DoctrineTestBundle/DependencyInjection/DAMADoctrineTestExtensionTest.php
@@ -12,7 +12,7 @@ class DAMADoctrineTestExtensionTest extends TestCase
     /**
      * @dataProvider loadDataProvider
      */
-    public function testLoad(array $configs, array $expectedProcessedConfig)
+    public function testLoad(array $configs, array $expectedProcessedConfig): void
     {
         $extension = new DAMADoctrineTestExtension();
         /** @var ContainerBuilder|MockObject $containerBuilder */
@@ -22,7 +22,7 @@ class DAMADoctrineTestExtensionTest extends TestCase
         $this->assertEquals($extension->getProcessedConfig(), $expectedProcessedConfig);
     }
 
-    public function loadDataProvider()
+    public function loadDataProvider(): array
     {
         return [
             [[], [

--- a/tests/DAMA/DoctrineTestBundle/DependencyInjection/DoctrineTestCompilerPassTest.php
+++ b/tests/DAMA/DoctrineTestBundle/DependencyInjection/DoctrineTestCompilerPassTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class DoctrineTestCompilerPassTest extends TestCase
 {
-    public function testProcess()
+    public function testProcess(): void
     {
         $extension = $this->createMock(DAMADoctrineTestExtension::class);
         $extension

--- a/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/MockDriver.php
+++ b/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/MockDriver.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\MockObject\Generator;
 
 class MockDriver implements Driver
 {
-    private function getMock(string $class): Generator
+    private function getMock(string $class)
     {
         return (new Generator())->getMock(
             $class,

--- a/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/MockDriver.php
+++ b/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/MockDriver.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\MockObject\Generator;
 
 class MockDriver implements Driver
 {
-    private function getMock(string $class)
+    private function getMock(string $class): Generator
     {
         return (new Generator())->getMock(
             $class,
@@ -24,7 +24,7 @@ class MockDriver implements Driver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = []): Driver\Connection
     {
         return $this->getMock(Driver\Connection::class);
     }
@@ -32,7 +32,7 @@ class MockDriver implements Driver
     /**
      * {@inheritdoc}
      */
-    public function getDatabasePlatform()
+    public function getDatabasePlatform(): AbstractPlatform
     {
         return $this->getMock(AbstractPlatform::class);
     }
@@ -40,7 +40,7 @@ class MockDriver implements Driver
     /**
      * {@inheritdoc}
      */
-    public function getSchemaManager(Connection $conn)
+    public function getSchemaManager(Connection $conn): AbstractSchemaManager
     {
         return $this->getMock(AbstractSchemaManager::class);
     }
@@ -48,7 +48,7 @@ class MockDriver implements Driver
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'mock';
     }
@@ -56,7 +56,7 @@ class MockDriver implements Driver
     /**
      * {@inheritdoc}
      */
-    public function getDatabase(Connection $conn)
+    public function getDatabase(Connection $conn): string
     {
         return 'mock';
     }

--- a/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactoryTest.php
+++ b/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactoryTest.php
@@ -15,7 +15,7 @@ class StaticConnectionFactoryTest extends TestCase
      * @param bool $keepStaticConnections
      * @param int  $expectedNestingLevel
      */
-    public function testCreateConnection($keepStaticConnections, $expectedNestingLevel)
+    public function testCreateConnection(bool $keepStaticConnections, int $expectedNestingLevel): void
     {
         $factory = new StaticConnectionFactory(new ConnectionFactory([]));
 
@@ -29,7 +29,7 @@ class StaticConnectionFactoryTest extends TestCase
         $this->assertSame($expectedNestingLevel, $connection->getTransactionNestingLevel());
     }
 
-    public function createConnectionDataProvider()
+    public function createConnectionDataProvider(): array
     {
         return [
             [false, 0],

--- a/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactoryTest.php
+++ b/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactoryTest.php
@@ -11,9 +11,6 @@ class StaticConnectionFactoryTest extends TestCase
 {
     /**
      * @dataProvider createConnectionDataProvider
-     *
-     * @param bool $keepStaticConnections
-     * @param int  $expectedNestingLevel
      */
     public function testCreateConnection(bool $keepStaticConnections, int $expectedNestingLevel): void
     {

--- a/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
+++ b/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
@@ -20,7 +20,7 @@ class StaticDriverTest extends TestCase
         $this->platform = $this->createMock(AbstractPlatform::class);
     }
 
-    public function testReturnCorrectPlatform()
+    public function testReturnCorrectPlatform(): void
     {
         $driver = new StaticDriver(new MockDriver(), $this->platform);
 
@@ -28,7 +28,7 @@ class StaticDriverTest extends TestCase
         $this->assertSame($this->platform, $driver->createDatabasePlatformForVersion('1'));
     }
 
-    public function testConnect()
+    public function testConnect(): void
     {
         $driver = new StaticDriver(new MockDriver(), $this->platform);
 

--- a/tests/Functional/AppKernel.php
+++ b/tests/Functional/AppKernel.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
@@ -16,7 +16,7 @@ class AppKernel extends Kernel
         ];
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/config.yml');
     }

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -30,31 +30,31 @@ class FunctionalTest extends TestCase
         $this->kernel->shutdown();
     }
 
-    private function assertRowCount($count)
+    private function assertRowCount($count): void
     {
         $this->assertEquals($count, $this->connection->fetchColumn('SELECT COUNT(*) FROM test'));
     }
 
-    private function insertRow()
+    private function insertRow(): void
     {
         $this->connection->insert('test', [
             'test' => 'foo',
         ]);
     }
 
-    public function testChangeDbState()
+    public function testChangeDbState(): void
     {
         $this->assertRowCount(0);
         $this->insertRow();
         $this->assertRowCount(1);
     }
 
-    public function testPreviousChangesAreRolledBack()
+    public function testPreviousChangesAreRolledBack(): void
     {
         $this->assertRowCount(0);
     }
 
-    public function testChangeDbStateWithinTransaction()
+    public function testChangeDbStateWithinTransaction(): void
     {
         $this->assertRowCount(0);
 
@@ -70,12 +70,12 @@ class FunctionalTest extends TestCase
         $this->assertRowCount(1);
     }
 
-    public function testPreviousChangesAreRolledBackAfterTransaction()
+    public function testPreviousChangesAreRolledBackAfterTransaction(): void
     {
         $this->assertRowCount(0);
     }
 
-    public function testChangeDbStateWithSavePoint()
+    public function testChangeDbStateWithSavePoint(): void
     {
         $this->assertRowCount(0);
         $this->connection->createSavepoint('foo');
@@ -86,7 +86,7 @@ class FunctionalTest extends TestCase
         $this->insertRow();
     }
 
-    public function testPreviousChangesAreRolledBackAfterUsingSavePoint()
+    public function testPreviousChangesAreRolledBackAfterUsingSavePoint(): void
     {
         $this->assertRowCount(0);
     }


### PR DESCRIPTION
Since next version of Symfony (4.4), missing return type will raise a warning. Something like

>Method XXX will return "string" as of its next major version. Doing the same in child class YYY will be required when upgrading.

This PR fixes such warnings, making this bundle forward-compatible with Symfony 4.4 (and Symfony 5), while keeping compatibility with older Symfony versions (as long as installed on php 7.1+, that is already a requirement for this bundle)