### PR TITLE
revive 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,39 +7,44 @@ services:
   - mysql
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 
 env:
-  - SYMFONY_VERSION="3.4.*"
-  - SYMFONY_VERSION="4.2.*"
-  - PHPUNIT_VERSION="6.*"
-  - PHPUNIT_VERSION="7.*"
+  - SYMFONY_REQUIRE="3.4.*"
+  - SYMFONY_REQUIRE="4.3.*"
+  - PHPUNIT_VERSION="8.*"
 
 matrix:
   include:
     - php: 7.3
       env:
         - TEST_COVERAGE=true
+    - php: 7.1
+      env:
+        - PHPUNIT_VERSION="7.*"
+        - SYMFONY_REQUIRE="3.4.*"
     - php: 7.3
       env:
-        - PHPUNIT_VERSION="8.*"
-        - SYMFONY_VERSION="4.2.*"
+        - STABILITY=dev
+        - SYMFONY_REQUIRE="4.4.*"
+
+before_install:
+    - phpenv config-rm xdebug.ini || echo "xDebug not disabled"
+    - composer global require --no-progress --no-scripts --no-plugins symfony/flex
 
 install:
   - rm -rf composer.lock vendor/*
-  - phpenv config-rm xdebug.ini || echo "xDebug not disabled"
-  - export COMPOSER_MEMORY_LIMIT=-1 && composer require symfony/symfony:${SYMFONY_VERSION:-"3.3.*"} phpunit/phpunit:${PHPUNIT_VERSION:-"7.*"}
+  - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
+  - composer require phpunit/phpunit:${PHPUNIT_VERSION:-"8.*"} --update-with-all-dependencies
 
 script:
   - cp tests/Functional/parameters.yml.dist tests/Functional/parameters.yml
   - rm -rf tests/Functional/cache
   - make phpstan php_cs_fixer_check
   - |
-    if [[ ${PHPUNIT_VERSION} != "8.*" && ${TEST_COVERAGE} ]]; then phpdbg -qrr vendor/bin/phpunit -c tests/ --coverage-clover ./build/logs/clover.xml;
-    elif [[ ${PHPUNIT_VERSION} == "8.*" && ${TEST_COVERAGE} ]]; then phpdbg -qrr vendor/bin/phpunit -c tests/phpunit8.xml --coverage-clover ./build/logs/clover.xml;
-    elif [[ ${PHPUNIT_VERSION} == "8.*" ]]; then vendor/bin/phpunit -c tests/phpunit8.xml tests/;
+    if [[ ${TEST_COVERAGE} ]]; then phpdbg -qrr vendor/bin/phpunit -c tests/ --coverage-clover ./build/logs/clover.xml;
+    elif [[ ${PHPUNIT_VERSION} == "7.*" ]]; then vendor/bin/phpunit -c tests/phpunit7.xml tests/;
     else vendor/bin/phpunit -c tests/ tests/;
     fi
 

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     "doctrine/doctrine-bundle": "~1.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "~6.0|~7.0|~8.0",
+    "phpunit/phpunit": "~7.0|~8.0",
     "symfony/yaml": "~2.8|~3.0|~4.0",
-    "symfony/phpunit-bridge": "~2.8|~3.0|~4.0"
+    "symfony/phpunit-bridge": "^4.3"
   },
   "autoload": {
     "psr-4": {

--- a/makefile
+++ b/makefile
@@ -8,14 +8,14 @@ tests/Functional/parameters.yml:
 test: tests/Functional/parameters.yml
 	vendor/bin/phpunit -c tests/ tests/
 
-test_phpunit_8: tests/Functional/parameters.yml
-	vendor/bin/phpunit -c tests/phpunit8.xml tests/
+test_phpunit_7: tests/Functional/parameters.yml
+	vendor/bin/phpunit -c tests/phpunit7.xml tests/
 
 phpstan: phpstan.phar
 	./phpstan.phar analyse -c phpstan.neon -a vendor/autoload.php -l 7 src
 
 phpstan.phar:
-	wget https://raw.githubusercontent.com/phpstan/phpstan-shim/0.10.1/phpstan.phar && chmod 777 phpstan.phar
+	wget https://raw.githubusercontent.com/phpstan/phpstan-shim/0.11.8/phpstan.phar && chmod 777 phpstan.phar
 
 build: composer.phar test phpstan php_cs_fixer_check
 
@@ -26,4 +26,4 @@ php_cs_fixer_check: php-cs-fixer.phar
 	./php-cs-fixer.phar fix --config .php_cs src tests --dry-run
 
 php-cs-fixer.phar:
-	wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.14.0/php-cs-fixer.phar && chmod 777 php-cs-fixer.phar
+	wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.15.1/php-cs-fixer.phar && chmod 777 php-cs-fixer.phar

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.2/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
     colors="true"
@@ -12,8 +12,12 @@
     bootstrap="./phpunit.bootstrap.php"
 >
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
     </php>
+
+    <extensions>
+        <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
+    </extensions>
 
     <testsuites>
         <testsuite name="DAMADoctrineTestBundle test suite">
@@ -29,6 +33,6 @@
   
     <listeners>
         <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-        <listener class="\DAMA\DoctrineTestBundle\PHPUnit\PHPUnitListener" />
     </listeners>
+
 </phpunit>

--- a/tests/phpunit7.xml
+++ b/tests/phpunit7.xml
@@ -1,6 +1,6 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.2/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
     colors="true"
@@ -12,12 +12,8 @@
     bootstrap="./phpunit.bootstrap.php"
 >
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
     </php>
-
-    <extensions>
-        <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
-    </extensions>
 
     <testsuites>
         <testsuite name="DAMADoctrineTestBundle test suite">
@@ -33,6 +29,6 @@
   
     <listeners>
         <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+        <listener class="\DAMA\DoctrineTestBundle\PHPUnit\PHPUnitListener" />
     </listeners>
-
 </phpunit>


### PR DESCRIPTION
Since Symfony 4.4 LTS will still support php 7.1 we should also still maintain this branch at least for bug fixes.