### PR TITLE
Allow doctrine-bundle v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
   ],
   "require": {
     "php": "^7.1",
-    "symfony/framework-bundle": "~2.7|~3.0|~4.0",
+    "symfony/framework-bundle": "~3.4|~4.0",
     "doctrine/dbal": "^2.9,>=2.9.3",
-    "doctrine/doctrine-bundle": "~1.4"
+    "doctrine/doctrine-bundle": "~1.4|~2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~7.0|~8.0",

--- a/tests/phpunit.bootstrap.php
+++ b/tests/phpunit.bootstrap.php
@@ -9,9 +9,6 @@ function bootstrap()
 
     $application = new \Symfony\Bundle\FrameworkBundle\Console\Application($kernel);
     $application->setAutoExit(false);
-    $application->add(new \Doctrine\Bundle\DoctrineBundle\Command\DropDatabaseDoctrineCommand());
-    $application->add(new \Doctrine\Bundle\DoctrineBundle\Command\CreateDatabaseDoctrineCommand());
-    $application->add(new \Doctrine\Bundle\DoctrineBundle\Command\Proxy\RunSqlDoctrineCommand());
 
     $application->run(new \Symfony\Component\Console\Input\ArrayInput([
         'command' => 'doctrine:database:drop',


### PR DESCRIPTION
Currently, this bundle is preventing from installing doctrine/doctrine-bundle v2, while doing so is the only way to be deprecation-free on SF4.4+PHP7.1 (as required by the symfony-demo app, e.g.)