### PR TITLE
Allow using FrameworkBundle 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": "^7.1",
-    "symfony/framework-bundle": "~3.4|~4.0",
+    "symfony/framework-bundle": "~3.4|~4.0|~5.0",
     "doctrine/dbal": "^2.9,>=2.9.3",
     "doctrine/doctrine-bundle": "~1.4|~2.0"
   },


### PR DESCRIPTION
I saw this when trying to update the Symfony Demo to Symfony 5.0:

```
  Problem 1
    - dama/doctrine-test-bundle v5.0.5 requires symfony/framework-bundle ~3.4|~4.0 -> satisfiable by symfony/framework-bundle[v4.3.3].
    - dama/doctrine-test-bundle v5.0.5 requires symfony/framework-bundle ~3.4|~4.0 -> satisfiable by symfony/framework-bundle[v4.3.3].
    - symfony/form v5.0.0 conflicts with symfony/framework-bundle[v4.3.3].
    - Installation request for symfony/form 5.0.* -> satisfiable by symfony/form[v5.0.0].
    - Installation request for dama/doctrine-test-bundle ^5.0.5 -> satisfiable by dama/doctrine-test-bundle[v5.0.5].
```