### PR TITLE
allow config per connection

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -9,11 +9,16 @@ return PhpCsFixer\Config::create()
         'array_syntax' => [
             'syntax' => 'short',
         ],
+        'general_phpdoc_annotation_remove' => [
+           'annotations' => ['author'],
+        ],
         'no_useless_return' => true,
         'phpdoc_to_comment' => false,
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'new_line_for_chained_calls',
         ],
         'no_superfluous_phpdoc_tags' => true,
+        'phpdoc_var_annotation_correct_order' => true,
+        'void_return' => true,
     ])
 ;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.3.0]
+### Changed
+- add support for enabling static transactional handling per doctrine dbal connection
+
 ## [6.2.0]
 ### Changed
 - drop support for unmaintained Symfony versions

--- a/README.md
+++ b/README.md
@@ -71,9 +71,19 @@ The bundle exposes a configuration that looks like this by default:
     
 ```yaml
 dama_doctrine_test:
-  enable_static_connection: true
-  enable_static_meta_data_cache: true
-  enable_static_query_cache: true
+    enable_static_connection: true
+    enable_static_meta_data_cache: true
+    enable_static_query_cache: true
+```
+
+Setting `enable_static_connection: true` means it will enable it for all configured doctrine dbal connections.
+
+You can selectively only enable it for some connections if required:
+
+```yaml
+dama_doctrine_test:
+    enable_static_connection:
+        connection_a: true
 ```
 
 ### Example

--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ test_phpunit_7: tests/Functional/parameters.yml
 	vendor/bin/phpunit -c tests/phpunit7.xml tests/
 
 phpstan: phpstan.phar
-	./phpstan.phar analyse -c phpstan.neon -a vendor/autoload.php -l 7 src
+	./phpstan.phar analyse -c phpstan.neon -a vendor/autoload.php -l 5 src
 
 phpstan.phar:
 	wget https://raw.githubusercontent.com/phpstan/phpstan-shim/0.11.8/phpstan.phar && chmod 777 phpstan.phar

--- a/src/DAMA/DoctrineTestBundle/DependencyInjection/Configuration.php
+++ b/src/DAMA/DoctrineTestBundle/DependencyInjection/Configuration.php
@@ -25,7 +25,29 @@ class Configuration implements ConfigurationInterface
         $root
             ->addDefaultsIfNotSet()
             ->children()
-                ->booleanNode(self::ENABLE_STATIC_CONNECTION)->defaultTrue()->end()
+                ->variableNode(self::ENABLE_STATIC_CONNECTION)
+                    ->defaultTrue()
+                    ->validate()
+                        ->ifTrue(function ($value) {
+                            if (is_bool($value)) {
+                                return false;
+                            }
+
+                            if (!is_array($value)) {
+                                return true;
+                            }
+
+                            foreach ($value as $k => $v) {
+                                if (!is_string($k) || !is_bool($v)) {
+                                    return true;
+                                }
+                            }
+
+                            return false;
+                        })
+                        ->thenInvalid('Must be a boolean or an array with name -> bool')
+                    ->end()
+                ->end()
                 ->booleanNode(self::STATIC_META_CACHE)->defaultTrue()->end()
                 ->booleanNode(self::STATIC_QUERY_CACHE)->defaultTrue()->end()
             ->end()

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
@@ -45,7 +45,10 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     public function connect(array $params, $username = null, $password = null, array $driverOptions = []): Connection
     {
         if (self::$keepStaticConnections) {
-            $key = sha1(serialize($params).$username.$password);
+            if (!isset($params['dama.connection_name'])) {
+                throw new \InvalidArgumentException('Did not find key "dama.connection_name" inside connection params.');
+            }
+            $key = $params['dama.connection_name'];
 
             if (!isset(self::$connections[$key])) {
                 self::$connections[$key] = $this->underlyingDriver->connect($params, $username, $password, $driverOptions);

--- a/tests/DAMA/DoctrineTestBundle/DependencyInjection/DAMADoctrineTestExtensionTest.php
+++ b/tests/DAMA/DoctrineTestBundle/DependencyInjection/DAMADoctrineTestExtensionTest.php
@@ -46,6 +46,21 @@ class DAMADoctrineTestExtensionTest extends TestCase
                     'enable_static_query_cache' => false,
                 ],
             ],
+            [[
+                [
+                    'enable_static_connection' => [
+                        'a' => true,
+                        'b' => false,
+                    ],
+                ],
+            ], [
+                'enable_static_connection' => [
+                    'a' => true,
+                    'b' => false,
+                ],
+                'enable_static_meta_data_cache' => true,
+                'enable_static_query_cache' => true,
+            ]],
         ];
     }
 }

--- a/tests/DAMA/DoctrineTestBundle/DependencyInjection/DoctrineTestCompilerPassTest.php
+++ b/tests/DAMA/DoctrineTestBundle/DependencyInjection/DoctrineTestCompilerPassTest.php
@@ -5,107 +5,132 @@ namespace Tests\DAMA\DoctrineTestBundle\DependencyInjection;
 use DAMA\DoctrineTestBundle\DependencyInjection\DAMADoctrineTestExtension;
 use DAMA\DoctrineTestBundle\DependencyInjection\DoctrineTestCompilerPass;
 use DAMA\DoctrineTestBundle\Doctrine\Cache\StaticArrayCache;
-use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticConnectionFactory;
-use PHPUnit\Framework\MockObject\MockObject;
+use Doctrine\Bundle\DoctrineBundle\ConnectionFactory;
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 class DoctrineTestCompilerPassTest extends TestCase
 {
-    public function testProcess(): void
+    /**
+     * @dataProvider processDataProvider
+     */
+    public function testProcess(array $config, callable $assertCallback, callable $expectationCallback = null): void
     {
-        $extension = $this->createMock(DAMADoctrineTestExtension::class);
-        $extension
-            ->expects($this->once())
-            ->method('getProcessedConfig')
-            ->willReturn([
+        $containerBuilder = new ContainerBuilder();
+        $extension = new DAMADoctrineTestExtension();
+        $containerBuilder->registerExtension($extension);
+
+        $extension->load([$config], $containerBuilder);
+
+        $containerBuilder->setParameter('doctrine.connections', ['a' => 0, 'b' => 1, 'c' => 2]);
+        $containerBuilder->setDefinition('doctrine.dbal.a_connection', new Definition(Connection::class, [[]]));
+        $containerBuilder->setDefinition('doctrine.dbal.b_connection', new Definition(Connection::class, [[]]));
+        $containerBuilder->setDefinition('doctrine.dbal.c_connection', new Definition(Connection::class, [[]]));
+        $containerBuilder->setDefinition('doctrine.dbal.connection_factory', new Definition(ConnectionFactory::class));
+
+        if ($expectationCallback !== null) {
+            $expectationCallback($this);
+        }
+
+        (new DoctrineTestCompilerPass())->process($containerBuilder);
+
+        $assertCallback($containerBuilder);
+    }
+
+    public function processDataProvider(): \Generator
+    {
+        yield 'default config' => [
+            [
                 'enable_static_connection' => true,
                 'enable_static_meta_data_cache' => true,
                 'enable_static_query_cache' => true,
-            ])
-        ;
+            ],
+            function (ContainerBuilder $containerBuilder): void {
+                $this->assertTrue($containerBuilder->hasDefinition('dama.doctrine.dbal.connection_factory'));
+                $this->assertSame(
+                    'doctrine.dbal.connection_factory',
+                    $containerBuilder->getDefinition('dama.doctrine.dbal.connection_factory')->getDecoratedService()[0]
+                );
 
-        /** @var ContainerBuilder|MockObject $containerBuilder */
-        $containerBuilder = $this->createMock(ContainerBuilder::class);
-        $containerBuilder
-            ->expects($this->once())
-            ->method('getExtension')
-            ->with('dama_doctrine_test')
-            ->willReturn($extension)
-        ;
-
-        $containerBuilder
-            ->expects($this->once())
-            ->method('getParameter')
-            ->with('doctrine.connections')
-            ->willReturn(['a' => 0, 'b' => 1, 'c' => 2])
-        ;
-
-        $containerBuilder
-            ->expects($this->exactly(6))
-            ->method('hasAlias')
-            ->withConsecutive(
-                ['doctrine.orm.a_metadata_cache'],
-                ['doctrine.orm.b_metadata_cache'],
-                ['doctrine.orm.c_metadata_cache'],
-                ['doctrine.orm.a_query_cache'],
-                ['doctrine.orm.b_query_cache'],
-                ['doctrine.orm.c_query_cache']
-            )
-            ->willReturn(true)
-        ;
-
-        $containerBuilder
-            ->expects($this->exactly(6))
-            ->method('removeAlias')
-            ->withConsecutive(
-                ['doctrine.orm.a_metadata_cache'],
-                ['doctrine.orm.b_metadata_cache'],
-                ['doctrine.orm.c_metadata_cache'],
-                ['doctrine.orm.a_query_cache'],
-                ['doctrine.orm.b_query_cache'],
-                ['doctrine.orm.c_query_cache']
-            )
-        ;
-
-        $containerBuilder
-            ->expects($this->exactly(7))
-            ->method('setDefinition')
-            ->withConsecutive(
-                [
-                    'dama.doctrine.dbal.connection_factory',
-                    (new Definition(StaticConnectionFactory::class))
-                        ->setDecoratedService('doctrine.dbal.connection_factory')
-                        ->addArgument('dama.doctrine.dbal.connection_factory.inner'),
-                ],
-                [
+                $cacheServiceIds = [
                     'doctrine.orm.a_metadata_cache',
-                    (new Definition(StaticArrayCache::class))->addMethodCall('setNamespace', [sha1('doctrine.orm.a_metadata_cache')]),
-                ],
-                [
                     'doctrine.orm.b_metadata_cache',
-                    (new Definition(StaticArrayCache::class))->addMethodCall('setNamespace', [sha1('doctrine.orm.b_metadata_cache')]),
-                ],
-                [
                     'doctrine.orm.c_metadata_cache',
-                    (new Definition(StaticArrayCache::class))->addMethodCall('setNamespace', [sha1('doctrine.orm.c_metadata_cache')]),
-                ],
-                [
                     'doctrine.orm.a_query_cache',
-                    (new Definition(StaticArrayCache::class))->addMethodCall('setNamespace', [sha1('doctrine.orm.a_query_cache')]),
-                ],
-                [
-                    'doctrine.orm.b_query_cache',
-                    (new Definition(StaticArrayCache::class))->addMethodCall('setNamespace', [sha1('doctrine.orm.b_query_cache')]),
-                ],
-                [
-                    'doctrine.orm.c_query_cache',
-                    (new Definition(StaticArrayCache::class))->addMethodCall('setNamespace', [sha1('doctrine.orm.c_query_cache')]),
-                ]
-            )
-        ;
+                    'doctrine.orm.b_metadata_cache',
+                    'doctrine.orm.c_metadata_cache',
+                ];
 
-        (new DoctrineTestCompilerPass())->process($containerBuilder);
+                foreach ($cacheServiceIds as $id) {
+                    $this->assertFalse($containerBuilder->hasAlias($id));
+                    $this->assertEquals(
+                        (new Definition(StaticArrayCache::class))->addMethodCall('setNamespace', [sha1($id)]),
+                        $containerBuilder->getDefinition($id)
+                    );
+                }
+
+                $this->assertSame([
+                    'dama.connection_name' => 'a',
+                    'dama.keep_static' => true,
+                ], $containerBuilder->getDefinition('doctrine.dbal.a_connection')->getArgument(0));
+            },
+        ];
+
+        yield 'disabled' => [
+            [
+                'enable_static_connection' => false,
+                'enable_static_meta_data_cache' => false,
+                'enable_static_query_cache' => false,
+            ],
+            function (ContainerBuilder $containerBuilder): void {
+                $this->assertFalse($containerBuilder->hasDefinition('dama.doctrine.dbal.connection_factory'));
+                $this->assertFalse($containerBuilder->hasDefinition('doctrine.orm.a_metadata_cache'));
+            },
+        ];
+
+        yield 'enabled per connection' => [
+            [
+                'enable_static_connection' => [
+                    'a' => true,
+                    'c' => true,
+                ],
+                'enable_static_meta_data_cache' => true,
+                'enable_static_query_cache' => true,
+            ],
+            function (ContainerBuilder $containerBuilder): void {
+                $this->assertTrue($containerBuilder->hasDefinition('dama.doctrine.dbal.connection_factory'));
+
+                $this->assertSame([
+                    'dama.connection_name' => 'a',
+                    'dama.keep_static' => true,
+                ], $containerBuilder->getDefinition('doctrine.dbal.a_connection')->getArgument(0));
+
+                $this->assertSame([], $containerBuilder->getDefinition('doctrine.dbal.b_connection')->getArgument(0));
+
+                $this->assertSame([
+                    'dama.connection_name' => 'c',
+                    'dama.keep_static' => true,
+                ], $containerBuilder->getDefinition('doctrine.dbal.c_connection')->getArgument(0));
+            },
+        ];
+
+        yield 'invalid connection names' => [
+            [
+                'enable_static_connection' => [
+                    'foo' => true,
+                    'bar' => true,
+                ],
+                'enable_static_meta_data_cache' => false,
+                'enable_static_query_cache' => false,
+            ],
+            function (ContainerBuilder $containerBuilder): void {
+            },
+            function (TestCase $testCase): void {
+                $testCase->expectException(\InvalidArgumentException::class);
+                $testCase->expectExceptionMessage('Unknown doctrine dbal connection name(s): foo, bar.');
+            },
+        ];
     }
 }

--- a/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
+++ b/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
@@ -35,9 +35,9 @@ class StaticDriverTest extends TestCase
         $driver::setKeepStaticConnections(true);
 
         /** @var StaticConnection $connection1 */
-        $connection1 = $driver->connect(['database_name' => 1], 'user1', 'pw1');
+        $connection1 = $driver->connect(['dama.connection_name' => 'foo']);
         /** @var StaticConnection $connection2 */
-        $connection2 = $driver->connect(['database_name' => 2], 'user1', 'pw2');
+        $connection2 = $driver->connect(['dama.connection_name' => 'bar']);
 
         $this->assertInstanceOf(StaticConnection::class, $connection1);
         $this->assertNotSame($connection1->getWrappedConnection(), $connection2->getWrappedConnection());
@@ -45,9 +45,9 @@ class StaticDriverTest extends TestCase
         $driver = new StaticDriver(new MockDriver(), $this->platform);
 
         /** @var StaticConnection $connectionNew1 */
-        $connectionNew1 = $driver->connect(['database_name' => 1], 'user1', 'pw1');
+        $connectionNew1 = $driver->connect(['dama.connection_name' => 'foo']);
         /** @var StaticConnection $connectionNew2 */
-        $connectionNew2 = $driver->connect(['database_name' => 2], 'user1', 'pw2');
+        $connectionNew2 = $driver->connect(['dama.connection_name' => 'bar']);
 
         $this->assertSame($connection1->getWrappedConnection(), $connectionNew1->getWrappedConnection());
         $this->assertSame($connection2->getWrappedConnection(), $connectionNew2->getWrappedConnection());

--- a/tests/phpunit.bootstrap.php
+++ b/tests/phpunit.bootstrap.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__.'/../vendor/autoload.php';
 
-function bootstrap()
+function bootstrap(): void
 {
     $kernel = new \Tests\Functional\AppKernel('test', true);
     $kernel->boot();


### PR DESCRIPTION
This fixes https://github.com/dmaicher/doctrine-test-bundle/issues/103 by allowing a config like

```yaml
dama_doctrine_test:
    enable_static_connection:
        default: true
```

So it allows to enable the static transactional connection per doctrine dbal connection name.

TODOs:
- [x] adjust readme
- [x] validate connection names