### PR TITLE
relax php requirement: allow php 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,13 @@ matrix:
     - php: 7.3
       env:
         - TEST_COVERAGE=true
-    - php: 7.3
+    - php: 7.1
       env:
         - PHPUNIT_VERSION="7.*"
         - SYMFONY_REQUIRE="3.4.*"
+    - php: 7.4
+      env:
+        - SYMFONY_REQUIRE="5.0.*"
 
 before_install:
     - phpenv config-rm xdebug.ini || echo "xDebug not disabled"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [6.3.0]
 ### Changed
 - add support for enabling static transactional handling per doctrine dbal connection
+- relaxed php requirement: allowing php 7.1 again
 
 ## [6.2.0]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![PHP Version](https://img.shields.io/badge/php-%5E7.2-blue.svg)](https://img.shields.io/badge/php-%5E7.2-blue.svg)
+[![PHP Version](https://img.shields.io/badge/php-%5E7.1-blue.svg)](https://img.shields.io/badge/php-%5E7.1-blue.svg)
 [![Stable release][Last stable image]][Packagist link]
 [![Unstable release][Last unstable image]][Packagist link]
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.1",
     "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0",
     "doctrine/dbal": "^2.9,>=2.9.3",
     "doctrine/doctrine-bundle": "^1.11 || ^2.0"
@@ -19,7 +19,8 @@
   "require-dev": {
     "phpunit/phpunit": "^7.0 || ^8.0",
     "symfony/yaml": "^3.4 || ^4.3 || ^5.0",
-    "symfony/phpunit-bridge": "^4.3 || ^5.0"
+    "symfony/phpunit-bridge": "^4.3 || ^5.0",
+    "phpstan/phpstan": "^0.12"
   },
   "autoload": {
     "psr-4": {

--- a/makefile
+++ b/makefile
@@ -11,11 +11,8 @@ test: tests/Functional/parameters.yml
 test_phpunit_7: tests/Functional/parameters.yml
 	vendor/bin/phpunit -c tests/phpunit7.xml tests/
 
-phpstan: phpstan.phar
-	./phpstan.phar analyse -c phpstan.neon -a vendor/autoload.php -l 5 src
-
-phpstan.phar:
-	wget https://raw.githubusercontent.com/phpstan/phpstan-shim/0.11.8/phpstan.phar && chmod 777 phpstan.phar
+phpstan:
+	vendor/bin/phpstan analyse -c phpstan.neon -a vendor/autoload.php -l 5 src
 
 build: composer.phar test phpstan php_cs_fixer_check
 
@@ -26,4 +23,4 @@ php_cs_fixer_check: php-cs-fixer.phar
 	./php-cs-fixer.phar fix --config .php_cs src tests --dry-run
 
 php-cs-fixer.phar:
-	wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.15.1/php-cs-fixer.phar && chmod 777 php-cs-fixer.phar
+	wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.16.1/php-cs-fixer.phar && chmod 777 php-cs-fixer.phar

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Functional;
 
 use Doctrine\DBAL\Connection;
-use Symfony\Component\HttpKernel\KernelInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class FunctionalTest extends TestCase
 {


### PR DESCRIPTION
The code base is 100% compatible with php 7.1. So let's support it as its no burden at all to do so :blush: 