### PR TITLE
fix StaticDriver::getDatabase return type hint

### DIFF
--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
@@ -85,7 +85,7 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
     /**
      * {@inheritdoc}
      */
-    public function getDatabase(\Doctrine\DBAL\Connection $conn): string
+    public function getDatabase(\Doctrine\DBAL\Connection $conn): ?string
     {
         return $this->underlyingDriver->getDatabase($conn);
     }


### PR DESCRIPTION
Fixes https://github.com/dmaicher/doctrine-test-bundle/issues/114

Although the interface states that it returns `string` it seems not all doctrine implementations adhere to that :confused: 