### PR TITLE
Opt out of running in transaction by implementing an empty interface

### DIFF
--- a/src/DAMA/DoctrineTestBundle/DependencyInjection/DoNotRunInTransactionInterface.php
+++ b/src/DAMA/DoctrineTestBundle/DependencyInjection/DoNotRunInTransactionInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace DAMA\DoctrineTestBundle\DependencyInjection;
+
+/**
+ * Empty interface. Tests defined in TestCases implementing it won't be run in transaction.
+ */
+interface DoNotRunInTransactionInterface
+{}

--- a/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitListener.php
+++ b/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitListener.php
@@ -2,6 +2,7 @@
 
 namespace DAMA\DoctrineTestBundle\PHPUnit;
 
+use DAMA\DoctrineTestBundle\DependencyInjection\DoNotRunInTransactionInterface;
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
 
 class PHPUnitListener implements \PHPUnit\Framework\TestListener
@@ -20,6 +21,7 @@ class PHPUnitListener implements \PHPUnit\Framework\TestListener
 
     public function startTestSuite(\PHPUnit\Framework\TestSuite $suite): void
     {
-        StaticDriver::setKeepStaticConnections(true);
+        $keepStatic = !is_subclass_of($suite->getName(), DoNotRunInTransactionInterface::class);
+        StaticDriver::setKeepStaticConnections($keepStatic);
     }
 }

--- a/tests/Functional/NoTransactionFunctionalTest.php
+++ b/tests/Functional/NoTransactionFunctionalTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Functional;
+
+use DAMA\DoctrineTestBundle\DependencyInjection\DoNotRunInTransactionInterface;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Tests that the opt-out from transactions using DoNotRunInTransactionInterface works.
+ */
+class NoTransactionFunctionalTest extends TestCase implements DoNotRunInTransactionInterface
+{
+    /**
+     * @var KernelInterface
+     */
+    private $kernel;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    protected function setUp(): void
+    {
+        $this->kernel = new AppKernel('test', true);
+        $this->kernel->boot();
+        $this->connection = $this->kernel->getContainer()->get('doctrine.dbal.default_connection');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->kernel->shutdown();
+    }
+
+    private function assertRowCount($count): void
+    {
+        $this->assertEquals($count, $this->connection->fetchColumn('SELECT COUNT(*) FROM test'));
+    }
+
+    private function insertRow(): void
+    {
+        $this->connection->insert('test', [
+            'test' => 'foo',
+        ]);
+    }
+
+    public function testNotRunInTransaction(): void
+    {
+        $this->insertRow();
+        $this->assertFalse($this->connection->isTransactionActive());
+        $this->assertRowCount(1);
+    }
+
+    public function testLastTestsResultsNotDeleted(): void
+    {
+        $this->assertRowCount(1);
+    }
+}


### PR DESCRIPTION
Recently I found myself in a situation where the code under test didn't work the same way as usual if wrapped in a transaction, and since changing this behaviour was not an option, I was looking for ways how to disable the transactions for just a single TestCase.
It would be an option to create a separate test suite with a separate `phpunit.xml` which wouldn't register the listener (or extension), but that's rather inconvenient, so I was looking for a way to opt out of the transactions while staying in the same test suite.
I came up with an empty interface (`DoNotRunInTransactionInterface`) which marks the TestCase implementing it as opting out of the transactions. The listener checks each TestCase for implementing that interface and handles it appropriately.

I know this PR is not ready to merge as is - there is some code copy-pasting in tests and the functionality is only implemented for the (deprecated) PHPUnit listener, not yet for the extension (where I've had some difficulties, but hopefully I would be able to overcome these). At this point of time I would first like to ask what you think of the idea as such. Would you ever merge this kind of functionality, or do you consider it bad idea?