### PR TITLE
fix issue 126: avoid re-using same connection

### DIFF
--- a/src/DAMA/DoctrineTestBundle/DependencyInjection/DoctrineTestCompilerPass.php
+++ b/src/DAMA/DoctrineTestBundle/DependencyInjection/DoctrineTestCompilerPass.php
@@ -77,6 +77,7 @@ class DoctrineTestCompilerPass implements CompilerPassInterface
         $connectionDefinition = $container->getDefinition(sprintf('doctrine.dbal.%s_connection', $name));
         $connectionOptions = $connectionDefinition->getArgument(0);
         $connectionOptions['dama.keep_static'] = true;
+        $connectionOptions['dama.connection_name'] = $name;
         $connectionDefinition->replaceArgument(0, $connectionOptions);
     }
 }

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
@@ -44,18 +44,18 @@ class StaticDriver implements Driver, ExceptionConverterDriver, VersionAwarePlat
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = []): Connection
     {
-        if (self::$keepStaticConnections) {
-            $key = sha1(serialize($params).$username.$password);
-
-            if (!isset(self::$connections[$key])) {
-                self::$connections[$key] = $this->underlyingDriver->connect($params, $username, $password, $driverOptions);
-                self::$connections[$key]->beginTransaction();
-            }
-
-            return new StaticConnection(self::$connections[$key]);
+        if (!self::$keepStaticConnections) {
+            return $this->underlyingDriver->connect($params, $username, $password, $driverOptions);
         }
 
-        return $this->underlyingDriver->connect($params, $username, $password, $driverOptions);
+        $key = $params['dama.connection_name'] ?? sha1(serialize($params).$username.$password);
+
+        if (!isset(self::$connections[$key])) {
+            self::$connections[$key] = $this->underlyingDriver->connect($params, $username, $password, $driverOptions);
+            self::$connections[$key]->beginTransaction();
+        }
+
+        return new StaticConnection(self::$connections[$key]);
     }
 
     /**

--- a/tests/DAMA/DoctrineTestBundle/DependencyInjection/DoctrineTestCompilerPassTest.php
+++ b/tests/DAMA/DoctrineTestBundle/DependencyInjection/DoctrineTestCompilerPassTest.php
@@ -73,6 +73,7 @@ class DoctrineTestCompilerPassTest extends TestCase
 
                 $this->assertSame([
                     'dama.keep_static' => true,
+                    'dama.connection_name' => 'a',
                 ], $containerBuilder->getDefinition('doctrine.dbal.a_connection')->getArgument(0));
             },
         ];
@@ -103,12 +104,14 @@ class DoctrineTestCompilerPassTest extends TestCase
 
                 $this->assertSame([
                     'dama.keep_static' => true,
+                    'dama.connection_name' => 'a',
                 ], $containerBuilder->getDefinition('doctrine.dbal.a_connection')->getArgument(0));
 
                 $this->assertSame([], $containerBuilder->getDefinition('doctrine.dbal.b_connection')->getArgument(0));
 
                 $this->assertSame([
                     'dama.keep_static' => true,
+                    'dama.connection_name' => 'c',
                 ], $containerBuilder->getDefinition('doctrine.dbal.c_connection')->getArgument(0));
             },
         ];

--- a/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
+++ b/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
@@ -45,11 +45,21 @@ class StaticDriverTest extends TestCase
         $driver = new StaticDriver(new MockDriver(), $this->platform);
 
         /** @var StaticConnection $connectionNew1 */
-        $connectionNew1 = $driver->connect(['dama.connection_name' => 'foo']);
+        $connectionNew1 = $driver->connect(['dama.connection_name' => 'foo'], 'username');
         /** @var StaticConnection $connectionNew2 */
-        $connectionNew2 = $driver->connect(['dama.connection_name' => 'bar']);
+        $connectionNew2 = $driver->connect(['dama.connection_name' => 'bar'], null, 'password');
 
         $this->assertSame($connection1->getWrappedConnection(), $connectionNew1->getWrappedConnection());
         $this->assertSame($connection2->getWrappedConnection(), $connectionNew2->getWrappedConnection());
+
+        /** @var StaticConnection $connection1 */
+        $connection1 = $driver->connect(['host' => 'foo']);
+        /** @var StaticConnection $connection2 */
+        $connection2 = $driver->connect(['host' => 'foo']);
+        $this->assertSame($connection1->getWrappedConnection(), $connection2->getWrappedConnection());
+
+        /** @var StaticConnection $connection3 */
+        $connection3 = $driver->connect(['host' => 'bar']);
+        $this->assertNotSame($connection1->getWrappedConnection(), $connection3->getWrappedConnection());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dmaicher/doctrine-test-bundle/issues/126

We now use the configured doctrine connection name as "unique key" to avoid re-using the same underlying static connection for different doctrine connections.