### PR TITLE
add test case that covers deprecated "ExceptionConverterDriver" logic

### DIFF
--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Functional;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -97,5 +98,11 @@ class FunctionalTest extends TestCase
         $this->connection->beginTransaction();
         $this->connection->commit();
         $this->assertRowCount(0);
+    }
+
+    public function testWillThrowSpecificException(): void
+    {
+        $this->expectException(TableNotFoundException::class);
+        $this->connection->insert('does_not_exist', ['foo' => 'bar']);
     }
 }


### PR DESCRIPTION
Test case to cover the deprecated `ExceptionConverterDriver` logic.

See https://github.com/dmaicher/doctrine-test-bundle/issues/129