### PR TITLE
Improve Travis build output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,25 +37,43 @@ matrix:
         - SKIP_CS_FIXER=1
 
 before_install:
-    - phpenv config-rm xdebug.ini || echo "xDebug not disabled"
-    - composer global require --no-progress --no-scripts --no-plugins symfony/flex
+  - phpenv config-rm xdebug.ini || echo "xDebug not disabled"
+  - composer global require --no-progress --no-scripts --no-plugins symfony/flex
+  - |
+      # inspired by Symfony's tfold helper, folds the output of successful commands
+      tfold () {
+          local title="$1"
+          local fold=$(echo $title | sed -r 's/[^-_A-Za-z0-9]+/./g')
+          shift
+          echo -e "travis_fold:start:$fold"
+          echo -e "\\e[1;34m$title\\e[0m"
+
+          bash -xc "$*" 2>&1
+
+          local ok=$?
+          (exit $ok) && echo -e "travis_fold:end:$fold"
+          (exit $ok)
+      }
+      export -f tfold
 
 install:
   - rm -rf composer.lock vendor/*
   - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
   - composer require phpunit/phpunit:${PHPUNIT_VERSION:-"8.*"} --update-with-all-dependencies
 
-script:
+before_script:
   - cp tests/Functional/app/parameters.yml.dist tests/Functional/app/parameters.yml
   - rm -rf tests/Functional/cache
-  - if [[ ${SKIP_CS_FIXER} != "1" ]]; then make php_cs_fixer_check; fi
-  - make phpstan
+
+script:
+  - if [[ ${SKIP_CS_FIXER} != "1" ]]; then tfold 'PHP CS Fixer' make php_cs_fixer_check; fi
+  - tfold 'PHPStan' make phpstan
   - |
-    if [[ ${TEST_COVERAGE} ]]; then phpdbg -qrr vendor/bin/phpunit -c tests/ --coverage-clover ./build/logs/clover.xml;
-    elif [[ ${PHPUNIT_VERSION} == "7.*" ]]; then vendor/bin/phpunit -c tests/phpunit7.xml tests/;
-    else vendor/bin/phpunit -c tests/ tests/;
+    if [[ ${TEST_COVERAGE} ]]; then tfold 'PHPUnit with Coverage' phpdbg -qrr vendor/bin/phpunit -c tests/ --coverage-clover ./build/logs/clover.xml;
+    elif [[ ${PHPUNIT_VERSION} == "7.*" ]]; then tfold 'PHPUnit 7' vendor/bin/phpunit -c tests/phpunit7.xml tests/;
+    else tfold 'PHPUnit' vendor/bin/phpunit -c tests/ tests/;
     fi
-  - vendor/bin/behat -c tests/behat.yml -fprogress
+  - tfold 'Behat' vendor/bin/behat -c tests/behat.yml -fprogress
 
 after_success:
   - if [[ ${TEST_COVERAGE} ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi

--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ php_cs_fixer_fix: php-cs-fixer.phar
 	./php-cs-fixer.phar fix --config .php_cs src tests
 
 php_cs_fixer_check: php-cs-fixer.phar
-	./php-cs-fixer.phar fix --config .php_cs src tests --dry-run
+	./php-cs-fixer.phar fix --config .php_cs src tests --dry-run --diff --diff-format=udiff
 
 php-cs-fixer.phar:
 	wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.16.6/php-cs-fixer.phar && chmod 777 php-cs-fixer.phar

--- a/tests/Functional/app/AppKernel.php
+++ b/tests/Functional/app/AppKernel.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Functional\app;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -19,5 +21,10 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/config.yml');
+    }
+
+    protected function build(ContainerBuilder $container): void
+    {
+        $container->register('logger', NullLogger::class);
     }
 }


### PR DESCRIPTION
I took the freedom to play a bit with the Travis config in this repository, as I had a hard time understanding the Travis output in my Behat PR:

* Register a `NullLogger` to hide log output in functional tests (Symfony outputs all logs to stderr if no logger is registered)
* Use Travis code fold helpers to fold output of successful commands
* Show the PHPCsFixer diff, so it's clear what to fix (without having to install the phar locally)

For now, this includes #128 to avoid rebasing this when that merged is merged.