### PR TITLE
Add doctrine/dbal version check to avoid using deprecated ExceptionCo…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "php": "^7.1 || ^8.0",
     "symfony/framework-bundle": "^3.4 || ^4.4 || ^5.1",
     "doctrine/dbal": "^2.9.3 || ^3.0",
-    "doctrine/doctrine-bundle": "^1.11 || ^2.0"
+    "doctrine/doctrine-bundle": "^1.11 || ^2.0",
+    "ocramius/package-versions": "^1.2 || ^2.0"
   },
   "require-dev": {
     "behat/behat": "^3.0",

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnection.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnection.php
@@ -2,7 +2,11 @@
 
 namespace DAMA\DoctrineTestBundle\Doctrine\DBAL;
 
-if (interface_exists(\Doctrine\DBAL\Driver\ExceptionConverterDriver::class)) {
+use PackageVersions\Versions;
+
+$dbalVersion = Versions::getVersion('doctrine/dbal');
+
+if (version_compare($dbalVersion, '2.11.0', '<')) {
     // dbal v2
     /**
      * Wraps a real connection and just skips the first call to beginTransaction as a transaction is already started on the underlying connection.

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
@@ -2,7 +2,11 @@
 
 namespace DAMA\DoctrineTestBundle\Doctrine\DBAL;
 
-if (interface_exists(\Doctrine\DBAL\Driver\ExceptionConverterDriver::class)) {
+use PackageVersions\Versions;
+
+$dbalVersion = Versions::getVersion('doctrine/dbal');
+
+if (version_compare($dbalVersion, '2.11.0', '<')) {
     // dbal v2
     class StaticDriver extends AbstractStaticDriverV2
     {


### PR DESCRIPTION
This PR:
- Adds `doctrine/dbal` version check to avoid using deprecated `ExceptionConverterDriver` start from dbal 2.11.0.

This fix works for the lowest supported version (2.9.3) as well.

related issue: https://github.com/dmaicher/doctrine-test-bundle/issues/129