### PR TITLE
Fix a deprecation message related to return types

### DIFF
--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/AbstractStaticConnection.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/AbstractStaticConnection.php
@@ -54,6 +54,9 @@ abstract class AbstractStaticConnection implements Connection
         return $this->connection;
     }
 
+    /**
+     * @return mixed
+     */
     public function quote($input, $type = ParameterType::STRING)
     {
         return $this->connection->quote($input, $type);


### PR DESCRIPTION
This fixes the following deprecation:

```
  1x: Method "Doctrine\DBAL\Driver\Connection::quote()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "DAMA\DoctrineTestBundle\Doctrine\DBAL\AbstractStaticConnection" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in AddUserCommandTest::testCreateUserNonInteractive from App\Tests\Command
```

which we found when upgrading Symfony Demo app to the upcoming Symfony 5.4. See https://github.com/symfony/demo/pull/1268#issuecomment-961933724