### PR TITLE
Fix wrapping connection with dynamic parameters

### DIFF
--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/AbstractStaticDriverV2.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/AbstractStaticDriverV2.php
@@ -19,7 +19,7 @@ abstract class AbstractStaticDriverV2 extends AbstractStaticDriver implements Ex
             return $this->underlyingDriver->connect($params, $username, $password, $driverOptions);
         }
 
-        $key = $params['dama.connection_name'] ?? sha1(serialize($params).$username.$password);
+        $key = sha1(serialize($params).$username.$password);
 
         if (!isset(self::$connections[$key])) {
             self::$connections[$key] = $this->underlyingDriver->connect($params, $username, $password, $driverOptions);

--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/AbstractStaticDriverV3.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/AbstractStaticDriverV3.php
@@ -19,7 +19,7 @@ abstract class AbstractStaticDriverV3 extends AbstractStaticDriver
             return $this->underlyingDriver->connect($params);
         }
 
-        $key = $params['dama.connection_name'] ?? sha1(serialize($params));
+        $key = sha1(serialize($params));
 
         if (!isset(self::$connections[$key])) {
             self::$connections[$key] = $this->underlyingDriver->connect($params);

--- a/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
+++ b/tests/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriverTest.php
@@ -34,10 +34,22 @@ class StaticDriverTest extends TestCase
 
         $driver::setKeepStaticConnections(true);
 
+        $params = [
+            'driver' => 'pdo_mysql',
+            'charset' => 'UTF8',
+            'host' => 'foo',
+            'dbname' => 'doctrine_test_bundle',
+            'user' => 'user',
+            'password' => 'password',
+            'port' => null,
+            'dama.keep_static' => true,
+            'dama.connection_name' => 'foo',
+        ];
+
         /** @var StaticConnection $connection1 */
-        $connection1 = $driver->connect(['dama.connection_name' => 'foo']);
+        $connection1 = $driver->connect(['dama.connection_name' => 'foo'] + $params, 'username');
         /** @var StaticConnection $connection2 */
-        $connection2 = $driver->connect(['dama.connection_name' => 'bar']);
+        $connection2 = $driver->connect(['dama.connection_name' => 'bar'] + $params, null, 'password');
 
         $this->assertInstanceOf(StaticConnection::class, $connection1);
         $this->assertNotSame($connection1->getWrappedConnection(), $connection2->getWrappedConnection());
@@ -45,21 +57,21 @@ class StaticDriverTest extends TestCase
         $driver = new StaticDriver(new MockDriver(), $this->platform);
 
         /** @var StaticConnection $connectionNew1 */
-        $connectionNew1 = $driver->connect(['dama.connection_name' => 'foo'], 'username');
+        $connectionNew1 = $driver->connect(['dama.connection_name' => 'foo'] + $params, 'username');
         /** @var StaticConnection $connectionNew2 */
-        $connectionNew2 = $driver->connect(['dama.connection_name' => 'bar'], null, 'password');
+        $connectionNew2 = $driver->connect(['dama.connection_name' => 'bar'] + $params, null, 'password');
 
         $this->assertSame($connection1->getWrappedConnection(), $connectionNew1->getWrappedConnection());
         $this->assertSame($connection2->getWrappedConnection(), $connectionNew2->getWrappedConnection());
 
         /** @var StaticConnection $connection1 */
-        $connection1 = $driver->connect(['host' => 'foo']);
+        $connection1 = $driver->connect($params);
         /** @var StaticConnection $connection2 */
-        $connection2 = $driver->connect(['host' => 'foo']);
+        $connection2 = $driver->connect($params);
         $this->assertSame($connection1->getWrappedConnection(), $connection2->getWrappedConnection());
 
         /** @var StaticConnection $connection3 */
-        $connection3 = $driver->connect(['host' => 'bar']);
+        $connection3 = $driver->connect(['host' => 'bar'] + $params);
         $this->assertNotSame($connection1->getWrappedConnection(), $connection3->getWrappedConnection());
     }
 }


### PR DESCRIPTION
When a connection has parameters defined dynamically at runtime, the same wrapped connection is used because the cache key is only based on the connection's name, leading to using a connection that does not honor the parameters.

Always using a cache key based on all parameters (including connection's name) prevents this.

I faced this issue while running a PHPUnit test suite in which the database name is defined via an environment variable and changes depending on the tests. When running the entire suite, some tests failed because they connected to the wrong database (the one used for the first test that created a connection) while each test passed when run individually.