### PR TITLE
fix issue 196 by relying on dama.keep_static param

### DIFF
--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/PostConnectEventListener.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/PostConnectEventListener.php
@@ -9,7 +9,9 @@ class PostConnectEventListener
     public function postConnect(ConnectionEventArgs $args): void
     {
         $connection = $args->getConnection();
-        if (!$connection->getDriver() instanceof StaticDriver) {
+        $params = $connection->getParams();
+
+        if (!array_key_exists('dama.keep_static', $params) || $params['dama.keep_static'] !== true) {
             return;
         }
 


### PR DESCRIPTION
Fixes https://github.com/dmaicher/doctrine-test-bundle/issues/196

We should not rely on the driver instance as it could be decorated 