### PR TITLE
Allow manual operations on static connections

### DIFF
--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/AbstractStaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/AbstractStaticDriver.php
@@ -20,6 +20,11 @@ abstract class AbstractStaticDriver implements Driver, VersionAwarePlatformDrive
     /**
      * @var bool
      */
+    protected static $manualOperations = false;
+
+    /**
+     * @var bool
+     */
     protected static $keepStaticConnections = false;
 
     /**
@@ -56,6 +61,16 @@ abstract class AbstractStaticDriver implements Driver, VersionAwarePlatformDrive
     public static function isKeepStaticConnections(): bool
     {
         return self::$keepStaticConnections;
+    }
+
+    public static function setManualOperations(bool $manualOperations): void
+    {
+        self::$manualOperations = $manualOperations;
+    }
+
+    public static function isManualOperations(): bool
+    {
+        return self::$manualOperations;
     }
 
     public static function beginTransaction(): void

--- a/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitExtension.php
+++ b/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitExtension.php
@@ -17,12 +17,16 @@ class PHPUnitExtension implements BeforeFirstTestHook, AfterLastTestHook, Before
 
     public function executeBeforeTest(string $test): void
     {
-        StaticDriver::beginTransaction();
+        if (!StaticDriver::isManualOperations()) {
+            StaticDriver::beginTransaction();
+        }
     }
 
     public function executeAfterTest(string $test, float $time): void
     {
-        StaticDriver::rollBack();
+        if (!StaticDriver::isManualOperations()) {
+            StaticDriver::rollBack();
+        }
     }
 
     public function executeAfterLastTest(): void


### PR DESCRIPTION
These small changes allow me to handle specific cases like dependent tests (#151 ), or disabling DAMA for a specific class (#182 )

Here's how I use it:

```
public static function setUpBeforeClass(): void
{
    StaticDriver::setManualOperations(true);
    StaticDriver::beginTransaction();
}

public static function tearDownAfterClass(): void
{
    StaticDriver::rollBack();
    StaticDriver::setManualOperations(false);
}
```

But it could also be used just for a few tests, like this:
```
public function testOne(): void
{
    StaticDriver::setManualOperations(true);

    $this->assertTrue(false);
}

/**
 * @depends testOne
 */
public function testTwo(): void
{
    // ...

    StaticDriver::setManualOperations(false);
}
```