### PR TITLE
Start new transaction only once

### DIFF
--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/PostConnectEventListener.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/PostConnectEventListener.php
@@ -16,6 +16,8 @@ class PostConnectEventListener
         // The underlying connection already has a transaction started.
         // We start a transaction on the connection as well
         // so the internal state ($_transactionNestingLevel) is in sync with the underlying connection.
-        $args->getConnection()->beginTransaction();
+        if ($args->getConnection()->getTransactionNestingLevel() === 0) {
+            $args->getConnection()->beginTransaction();
+        }
     }
 }


### PR DESCRIPTION
If adding some `doctrine.event_subscriber` which injects current connection or other services which inject current connection, the `\DAMA\DoctrineTestBundle\Doctrine\DBAL\PostConnectEventListener` will be registered two or more times, and the connection will be wrapped into tow or more transactions. 