### PR TITLE
Fix resetting static connections after test with data provider

### DIFF
--- a/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitExtension.php
+++ b/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitExtension.php
@@ -7,10 +7,10 @@ use PHPUnit\Event\Test\Finished as TestFinishedEvent;
 use PHPUnit\Event\Test\FinishedSubscriber as TestFinishedSubscriber;
 use PHPUnit\Event\Test\PreparationStarted as TestStartedEvent;
 use PHPUnit\Event\Test\PreparationStartedSubscriber as TestStartedSubscriber;
-use PHPUnit\Event\TestSuite\Finished as TestSuiteFinishedEvent;
-use PHPUnit\Event\TestSuite\FinishedSubscriber as TestSuiteFinishedSubscriber;
-use PHPUnit\Event\TestSuite\Started as TestSuiteStartedEvent;
-use PHPUnit\Event\TestSuite\StartedSubscriber as TestSuiteStartedSubscriber;
+use PHPUnit\Event\TestRunner\Finished as TestRunnerFinishedEvent;
+use PHPUnit\Event\TestRunner\FinishedSubscriber as TestRunnerFinishedSubscriber;
+use PHPUnit\Event\TestRunner\Started as TestRunnerStartedEvent;
+use PHPUnit\Event\TestRunner\StartedSubscriber as TestRunnerStartedSubscriber;
 use PHPUnit\Runner\AfterLastTestHook;
 use PHPUnit\Runner\AfterTestHook;
 use PHPUnit\Runner\BeforeFirstTestHook;
@@ -20,7 +20,7 @@ use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
 
-if (class_exists(TestSuiteStartedEvent::class)) {
+if (class_exists(TestRunnerStartedEvent::class)) {
     /**
      * PHPUnit >= 10.
      */
@@ -28,8 +28,8 @@ if (class_exists(TestSuiteStartedEvent::class)) {
     {
         public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
         {
-            $facade->registerSubscriber(new class() implements TestSuiteStartedSubscriber {
-                public function notify(TestSuiteStartedEvent $event): void
+            $facade->registerSubscriber(new class() implements TestRunnerStartedSubscriber {
+                public function notify(TestRunnerStartedEvent $event): void
                 {
                     StaticDriver::setKeepStaticConnections(true);
                 }
@@ -49,8 +49,8 @@ if (class_exists(TestSuiteStartedEvent::class)) {
                 }
             });
 
-            $facade->registerSubscriber(new class() implements TestSuiteFinishedSubscriber {
-                public function notify(TestSuiteFinishedEvent $event): void
+            $facade->registerSubscriber(new class() implements TestRunnerFinishedSubscriber {
+                public function notify(TestRunnerFinishedEvent $event): void
                 {
                     StaticDriver::setKeepStaticConnections(false);
                 }

--- a/tests/Functional/PhpunitTest.php
+++ b/tests/Functional/PhpunitTest.php
@@ -29,19 +29,19 @@ class PhpunitTest extends TestCase
     /**
      * @dataProvider someDataProvider
      */
-    public function testWithDataProvider(string $argument): void
+    public function testWithDataProvider(int $expectedRowCount): void
     {
-        $this->assertRowCount(0);
+        $this->assertRowCount($expectedRowCount);
         $this->insertRow();
         $this->assertTrue($this->connection->isTransactionActive());
     }
 
     /**
-     * @return iterable<array{string}>
+     * @return iterable<array{int}>
      */
     public static function someDataProvider(): iterable
     {
-        yield ['string1'];
+        yield [0];
     }
 
     public function testChangeDbStateForReplicaConnection(): void

--- a/tests/Functional/PhpunitTest.php
+++ b/tests/Functional/PhpunitTest.php
@@ -26,6 +26,24 @@ class PhpunitTest extends TestCase
         $this->assertTrue($this->connection->isTransactionActive());
     }
 
+    /**
+     * @dataProvider someDataProvider
+     */
+    public function testWithDataProvider(string $argument): void
+    {
+        $this->assertRowCount(0);
+        $this->insertRow();
+        $this->assertTrue($this->connection->isTransactionActive());
+    }
+
+    /**
+     * @return iterable<array{string}>
+     */
+    public static function someDataProvider(): iterable
+    {
+        yield ['string1'];
+    }
+
     public function testChangeDbStateForReplicaConnection(): void
     {
         $this->connection = $this->kernel->getContainer()->get('doctrine.dbal.replica_connection');


### PR DESCRIPTION
Not entirely sure if this is the best possible solution, probably not, but it seems like Test using `dataProvider` is treated as a TestSuite (extension is receiving Started/Finished events twice) and it resets static connection too soon :thinking: 

Making the flow look like this:
* TestSuiteStarted -> staticConnections(true)
* (test with data provider)
* TestSuiteStarted -> staticConnections(true)
* TestSuiteFinished -> staticConnections(false)
* (next test)
* (next test) -> state from previous test not rolled back :cry: 
* TestSuiteFinished -> staticConnections(false) (again)