### PR TITLE
feature: add support for converting exceptions

### DIFF
--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
@@ -55,7 +55,7 @@ class StaticDriver extends Driver\Middleware\AbstractDriverMiddleware
             throw new \RuntimeException('This bundle only works for database platforms that support savepoints.');
         }
 
-        return new StaticConnection($connection, $platform);
+        return new StaticConnection($this->underlyingDriver, $connection, $platform);
     }
 
     public static function setKeepStaticConnections(bool $keepStaticConnections): void


### PR DESCRIPTION
This is sort of a regression from v7, where by exception conversion is lost when creating and releasing savepoints.

This is because the transcations handling for savepoints and exception conversion was previously done in `Doctrine\DBAL\Connection`, but since that's now moved to the `StaticConnection`, exception handling needs to be done there.