### PR TITLE
Use Symfony 5.4+ installation (bundles.php)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,32 +15,31 @@ It also includes a `Psr6StaticArrayCache` that will be automatically configured 
 
 1. install via composer
 
-    ```sh
-    composer require --dev dama/doctrine-test-bundle
-    ```
+```bash
+composer require --dev dama/doctrine-test-bundle
+```
 
-2. Enable the bundle for your test environment in your `AppKernel.php`
+2. If you're not using Flex, enable the bundle by adding the class to bundles.php
+```php
+<?php
+// config/bundles.php
 
-    ```php
-    if (in_array($env, ['dev', 'test'])) {
-        ...
-        if ($env === 'test') {
-            $bundles[] = new DAMA\DoctrineTestBundle\DAMADoctrineTestBundle();
-        }
-    }
-    ```
-
-   Note: if you are using symfony flex and you are allowing contrib recipes (`extra.symfony.allow-contrib=true`) then the bundle will be automatically enabled for the `'test'` environment. See https://github.com/symfony/recipes-contrib/tree/master/dama/doctrine-test-bundle
+return [
+    //...
+    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
+    //...
+];
+```
 
 3. Starting from version 8 you need to make sure you have `use_savepoints` enabled on your doctrine DBAL configuration for all relevant connections:
 
-   ```yaml
-   doctrine:
-       dbal:
-           connections:
-               default:
-                   use_savepoints: true
-    ``` 
+```yaml
+doctrine:
+   dbal:
+       connections:
+           default:
+               use_savepoints: true
+``` 
     
 #### Using the Bundle with PHPUnit
 


### PR DESCRIPTION
The AppKernel.php method was for Symfony < 5.4, this cleans up the installation instructions.