### PR TITLE
Added the ability to extend StaticDriver for greater flexibility

### DIFF
--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php
@@ -28,14 +28,14 @@ class StaticDriver extends Driver\Middleware\AbstractDriverMiddleware
             return parent::connect($params);
         }
 
-        $key = sha1(json_encode($params));
+        $key = $this->getConnectionHash($params);
 
-        if (!isset(self::$connections[$key])) {
-            self::$connections[$key] = parent::connect($params);
-            self::$connections[$key]->beginTransaction();
+        $connection = $this->getConnection($key);
+        if (null === $connection) {
+            $connection = parent::connect($params);
+            $this->addConnection($key, $connection);
+            $connection->beginTransaction();
         }
-
-        $connection = self::$connections[$key];
 
         $platform = $this->getPlatform($connection, $params);
 
@@ -75,6 +75,21 @@ class StaticDriver extends Driver\Middleware\AbstractDriverMiddleware
         foreach (self::$connections as $connection) {
             $connection->commit();
         }
+    }
+
+    protected function getConnectionHash(array $params): string
+    {
+        return sha1(json_encode($params));
+    }
+
+    protected function getConnection(string $key): ?Connection
+    {
+        return self::$connections[$key] ?? null;
+    }
+
+    protected function addConnection(string $key, Connection $connection): void
+    {
+        self::$connections[$key] = $connection;
     }
 
     private function getPlatform(Connection $connection, array $params): AbstractPlatform


### PR DESCRIPTION
Hi! 
I use this package to run tests, but have some troubles with it.

I have 2 connections to different databases in the production. Master server had one database and local servers that have their own databases and database replicated from master server. Doctrine have 2 connections. For the tests I want to have 1 connection to two local databases without replication. But they have different SHA hash string, and I cannot see transactions that I made with first database on the second connenction.

With this changes I will be able to extend StaticDriver and get hash from only a few parameters, for example:
```
json_encode([
       'driver'        => $params['driver'],
       'host'          => $params['host'],
       'port'          => $params['port'],
       'user'          => $params['user'],
       'password'      => $params['password'],
       'dbname'        => $params['dbname'],
       'driverOptions' => $params['driverOptions'],
])
````
