### PR TITLE
drop support for PHP 7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    -   php: 7.3
-                        test_make_target: test_phpunit_legacy
                     -   php: 7.4
                         composer_flags: --prefer-lowest
                         test_make_target: test_phpunit_legacy

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "doctrine/dbal": "^3.3 || ^4.0",
         "doctrine/doctrine-bundle": "^2.2.2",


### PR DESCRIPTION
- makes life easier for using mysql 8 with `caching_sha2` authentication on CI
- less than 0.1% installs for 7.3