### PR TITLE
roll back transactions for tests marked as incomplete in setUp()

### DIFF
--- a/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitExtension.php
+++ b/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitExtension.php
@@ -3,6 +3,8 @@
 namespace DAMA\DoctrineTestBundle\PHPUnit;
 
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
+use PHPUnit\Event\Test\BeforeTestMethodErrored;
+use PHPUnit\Event\Test\BeforeTestMethodErroredSubscriber;
 use PHPUnit\Event\Test\Errored;
 use PHPUnit\Event\Test\ErroredSubscriber;
 use PHPUnit\Event\Test\Finished as TestFinishedEvent;
@@ -71,6 +73,14 @@ if (class_exists(TestRunnerStartedEvent::class)) {
             $facade->registerSubscriber(new class implements TestFinishedSubscriber {
                 public function notify(TestFinishedEvent $event): void
                 {
+                    PHPUnitExtension::rollBack();
+                }
+            });
+
+            $facade->registerSubscriber(new class implements BeforeTestMethodErroredSubscriber {
+                public function notify(BeforeTestMethodErrored $event): void
+                {
+                    // needed for tests marked incomplete during setUp()
                     PHPUnitExtension::rollBack();
                 }
             });

--- a/tests/Functional/PhpunitTest.php
+++ b/tests/Functional/PhpunitTest.php
@@ -18,6 +18,11 @@ class PhpunitTest extends TestCase
         if ((method_exists($this, 'name') ? $this->name() : $this->getName()) === 'testSkippedTestDuringSetup') {
             $this->markTestSkipped();
         }
+
+        /** @phpstan-ignore-next-line */
+        if ((method_exists($this, 'name') ? $this->name() : $this->getName()) === 'testIncompleteTestDuringSetup') {
+            $this->markTestIncomplete();
+        }
     }
 
     public function testChangeDbState(): void
@@ -143,6 +148,11 @@ class PhpunitTest extends TestCase
     }
 
     public function testSkippedTestDuringSetup(): void
+    {
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testIncompleteTestDuringSetup(): void
     {
         $this->expectNotToPerformAssertions();
     }


### PR DESCRIPTION
The test suite would fail like this without the changes in the `PHPUnitExtension`:

```
PHPUnit 11.5.6 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.27
Configuration: /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/tests/phpunit.xml

........................SSI....

Time: 00:00.060, Memory: 26.00 MB

There was 1 PHPUnit test runner warning:

1) Exception in third-party event subscriber: There is already an active transaction
#0 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/doctrine/dbal/src/Driver/PDO/Connection.php(107): Doctrine\DBAL\Driver\PDO\Exception::new()
#1 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticDriver.php(60): Doctrine\DBAL\Driver\PDO\Connection->beginTransaction()
#2 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitExtension.php(57): DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver::beginTransaction()
#3 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/phpunit/phpunit/src/Event/Dispatcher/DirectDispatcher.php(106): PHPUnit\Event\Test\PreparationStartedSubscriber@anonymous->notify()
#4 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/phpunit/phpunit/src/Event/Dispatcher/DeferringDispatcher.php(47): PHPUnit\Event\DirectDispatcher->dispatch()
#5 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/phpunit/phpunit/src/Event/Emitter/DispatchingEmitter.php(318): PHPUnit\Event\DeferringDispatcher->dispatch()
#6 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/phpunit/phpunit/src/Framework/TestCase.php(478): PHPUnit\Event\DispatchingEmitter->testPreparationStarted()
#7 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/phpunit/phpunit/src/Framework/TestRunner/TestRunner.php(87): PHPUnit\Framework\TestCase->runBare()
#8 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/phpunit/phpunit/src/Framework/TestCase.php(361): PHPUnit\Framework\TestRunner->run()
#9 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/phpunit/phpunit/src/Framework/TestSuite.php(369): PHPUnit\Framework\TestCase->run()
#10 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/phpunit/phpunit/src/Framework/TestSuite.php(369): PHPUnit\Framework\TestSuite->run()
#11 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(64): PHPUnit\Framework\TestSuite->run()
#12 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/phpunit/phpunit/src/TextUI/Application.php(210): PHPUnit\TextUI\TestRunner->run()
#13 /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/phpunit/phpunit/phpunit(104): PHPUnit\TextUI\Application->run()
#[14](https://github.com/xabbuh/doctrine-test-bundle/actions/runs/13088439798/job/36522368758#step:9:15) /home/runner/work/doctrine-test-bundle/doctrine-test-bundle/vendor/bin/phpunit(122): include('...')
#[15](https://github.com/xabbuh/doctrine-test-bundle/actions/runs/13088439798/job/36522368758#step:9:16) {main}

WARNINGS!
Tests: 31, Assertions: 108, Warnings: 1, PHPUnit Deprecations: 8, Skipped: 2, Incomplete: 2.
```