### PR TITLE
fix PHPUnit 12.2.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ vendor
 .php-cs-fixer.cache
 php-cs-fixer.phar
 .phpunit.result.cache
-tests/.phpunit.cache/
 .idea
+.phpunit.cache

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ tests/Functional/app/parameters.yml:
 	cp tests/Functional/app/parameters.yml.dist tests/Functional/app/parameters.yml
 
 test: tests/Functional/app/parameters.yml
-	vendor/bin/phpunit -c tests/ tests/
+	vendor/bin/phpunit
 
 phpstan:
 	vendor/bin/phpstan analyse -c phpstan.neon -a vendor/autoload.php -l 8 src

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,8 +5,9 @@
          colors="true"
          processIsolation="false"
          stderr="true"
-         bootstrap="./bootstrap.php"
+         bootstrap="tests/bootstrap.php"
          cacheDirectory=".phpunit.cache"
+
          backupStaticProperties="false">
     <php>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=2"/>
@@ -16,7 +17,7 @@
     </extensions>
     <testsuites>
         <testsuite name="DAMADoctrineTestBundle test suite">
-            <directory>../tests</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitExtension.php
+++ b/src/DAMA/DoctrineTestBundle/PHPUnit/PHPUnitExtension.php
@@ -5,6 +5,8 @@ namespace DAMA\DoctrineTestBundle\PHPUnit;
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
 use PHPUnit\Event\Test\BeforeTestMethodErrored;
 use PHPUnit\Event\Test\BeforeTestMethodErroredSubscriber;
+use PHPUnit\Event\Test\BeforeTestMethodFailed;
+use PHPUnit\Event\Test\BeforeTestMethodFailedSubscriber;
 use PHPUnit\Event\Test\Errored;
 use PHPUnit\Event\Test\ErroredSubscriber;
 use PHPUnit\Event\Test\Finished as TestFinishedEvent;
@@ -73,7 +75,17 @@ class PHPUnitExtension implements Extension
             $facade->registerSubscriber(new class implements BeforeTestMethodErroredSubscriber {
                 public function notify(BeforeTestMethodErrored $event): void
                 {
-                    // needed for tests marked incomplete during setUp()
+                    // needed for tests that error (or marked incomplete for PHPUnit < 12.2.0) during setUp()
+                    PHPUnitExtension::rollBack();
+                }
+            });
+        }
+
+        if (interface_exists(BeforeTestMethodFailedSubscriber::class)) {
+            $facade->registerSubscriber(new class implements BeforeTestMethodFailedSubscriber {
+                public function notify(BeforeTestMethodFailed $event): void
+                {
+                    // needed for tests that fail (or marked incomplete for PHPUnit >= 12.2.0) during setUp()
                     PHPUnitExtension::rollBack();
                 }
             });


### PR DESCRIPTION
marking tests incomplete during `setUp()` now triggers `BeforeTestMethodFailed` instead of `BeforeTestMethodErrored` 