### PR TITLE
fix deprecation

### DIFF
--- a/tests/Functional/PhpunitTest.php
+++ b/tests/Functional/PhpunitTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Exception\TableNotFoundException;
 use PHPUnit\Event\Test\BeforeTestMethodErroredSubscriber;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 
 class PhpunitTest extends TestCase
@@ -60,6 +61,7 @@ class PhpunitTest extends TestCase
         yield [0];
     }
 
+    #[IgnoreDeprecations(/* 'Support for MySQL < 8 is deprecated and will be removed' */)]
     public function testChangeDbStateForReplicaConnection(): void
     {
         $this->connection = $this->kernel->getContainer()->get('doctrine.dbal.replica_connection');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,6 +38,7 @@ function bootstrap(): void
     $connection->executeQuery('CREATE TABLE test (test VARCHAR(10))');
 
     $kernel->shutdown();
+    restore_error_handler();
 }
 
 bootstrap();


### PR DESCRIPTION
Fix

```
1) /var/www/doctrine-test-bundle/vendor/doctrine/deprecations/src/Deprecation.php:208
Support for MySQL < 8 is deprecated and will be removed in DBAL 5 (AbstractMySQLDriver.php:75 called by AbstractDriverMiddleware.php:32, https://github.com/doctrine/dbal/pull/6343, package doctrine/dbal)

Triggered by:

* Tests\Functional\PhpunitTest::testChangeDbStateForReplicaConnection
  /var/www/doctrine-test-bundle/tests/Functional/PhpunitTest.php:63
