### PR TITLE
fix PHP8.4 deprecations

### DIFF
--- a/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactory.php
+++ b/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactory.php
@@ -20,7 +20,7 @@ class StaticConnectionFactory extends ConnectionFactory
         $this->decoratedFactory = $decoratedFactory;
     }
 
-    public function createConnection(array $params, Configuration $config = null, EventManager $eventManager = null, array $mappingTypes = []): Connection
+    public function createConnection(array $params, ?Configuration $config = null, ?EventManager $eventManager = null, array $mappingTypes = []): Connection
     {
         $connection = $this->decoratedFactory->createConnection($params, $config, $eventManager, $mappingTypes);
 


### PR DESCRIPTION
I know this version is not supported anymore but we need to fix theses issues : 

<details>
<summary>See deprecations</summary>

```
[1mFILE: /home/jravia/code/ticketing/vendor/dama/doctrine-test-bundle/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactory.php[0m
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[1mFOUND 0 ERRORS AND 2 WARNINGS AFFECTING 1 LINE[0m
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 23 | [33mWARNING[0m | [1mImplicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $config.[0m
    |         | (PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam.Deprecated)
 23 | [33mWARNING[0m | [1mImplicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $eventManager.[0m
    |         | (PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam.Deprecated)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

</details>