### PR TITLE
Add #[SkipStaticDatabaseConnection] attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ doctrine:
 
 3. That's it! From now on whatever changes you do to the database within each single testcase (be it a `WebTestCase` or a `KernelTestCase` or any custom test) are automatically rolled back for you :blush:
 
+##### Skipping the transactional database connection handling for specific tests
+
+With PHPUnit you can skip this bundle's transactional database connection handling for specific tests if needed:
+
+```php
+#[SkipStaticDatabaseConnection] // this will skip it for all tests in a class
+public class MyTest extends \PHPUnit\Framework\TestCase
+
+#[SkipStaticDatabaseConnection] // this will skip it for only one test method
+public function MyTest()
+```
+
 #### Using the Bundle with Behat
 
 Enable the extension in your Behat config (e.g. `behat.yml`)

--- a/src/Behat/BehatListener.php
+++ b/src/Behat/BehatListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DAMA\DoctrineTestBundle\Behat;
 
 use Behat\Behat\EventDispatcher\Event\ExampleTested;
@@ -8,6 +10,9 @@ use Behat\Testwork\EventDispatcher\Event\ExerciseCompleted;
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+/**
+ * @final
+ */
 class BehatListener implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array

--- a/src/Behat/ServiceContainer/DoctrineExtension.php
+++ b/src/Behat/ServiceContainer/DoctrineExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DAMA\DoctrineTestBundle\Behat\ServiceContainer;
 
 use Behat\Testwork\EventDispatcher\ServiceContainer\EventDispatcherExtension;
@@ -9,6 +11,9 @@ use DAMA\DoctrineTestBundle\Behat\BehatListener;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * @final
+ */
 class DoctrineExtension implements Extension
 {
     public function getConfigKey(): string

--- a/src/DAMADoctrineTestBundle.php
+++ b/src/DAMADoctrineTestBundle.php
@@ -8,6 +8,9 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @final
+ */
 class DAMADoctrineTestBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -5,6 +5,9 @@ namespace DAMA\DoctrineTestBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
+/**
+ * @final
+ */
 class Configuration implements ConfigurationInterface
 {
     public const ENABLE_STATIC_CONNECTION = 'enable_static_connection';

--- a/src/DependencyInjection/DAMADoctrineTestExtension.php
+++ b/src/DependencyInjection/DAMADoctrineTestExtension.php
@@ -5,6 +5,9 @@ namespace DAMA\DoctrineTestBundle\DependencyInjection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 
+/**
+ * @final
+ */
 class DAMADoctrineTestExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void

--- a/src/Doctrine/DBAL/StaticConnection.php
+++ b/src/Doctrine/DBAL/StaticConnection.php
@@ -10,6 +10,9 @@ use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
  */
 if (method_exists(Connection::class, 'getEventManager')) {
     // DBAL < 4
+    /**
+     * @final
+     */
     class StaticConnection extends AbstractConnectionMiddleware
     {
         use StaticConnectionTrait;
@@ -37,6 +40,9 @@ if (method_exists(Connection::class, 'getEventManager')) {
     }
 } else {
     // DBAL >= 4
+    /**
+     * @final
+     */
     class StaticConnection extends AbstractConnectionMiddleware
     {
         use StaticConnectionTrait;

--- a/src/Doctrine/DBAL/StaticDriver.php
+++ b/src/Doctrine/DBAL/StaticDriver.php
@@ -7,6 +7,9 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
+/**
+ * @final
+ */
 class StaticDriver extends Driver\Middleware\AbstractDriverMiddleware
 {
     /**

--- a/src/PHPUnit/SkipStaticDatabaseConnection.php
+++ b/src/PHPUnit/SkipStaticDatabaseConnection.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DAMA\DoctrineTestBundle\PHPUnit;
+
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
+final class SkipStaticDatabaseConnection
+{
+}

--- a/tests/Functional/PhpunitTest.php
+++ b/tests/Functional/PhpunitTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Functional;
 
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
+use DAMA\DoctrineTestBundle\PHPUnit\SkipStaticDatabaseConnection;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use PHPUnit\Event\Test\BeforeTestMethodErroredSubscriber;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -204,5 +205,22 @@ class PhpunitTest extends TestCase
         $this->assertRowCount(0);
 
         StaticDriver::setKeepStaticConnections(true);
+    }
+
+    #[SkipStaticDatabaseConnection]
+    public function testTransactionalBehaviorDisabledWithAttribute(): void
+    {
+        $this->insertRow();
+        $this->assertRowCount(1);
+    }
+
+    #[SkipStaticDatabaseConnection]
+    #[Depends('testTransactionalBehaviorDisabledWithAttribute')]
+    public function testChangesFromPreviousTestAreVisibleWhenDisabledWithAttribute(): void
+    {
+        $this->assertRowCount(1);
+
+        // cleanup persisted row to not affect any other tests afterwards
+        $this->connection->executeQuery('DELETE FROM test');
     }
 }

--- a/tests/Functional/PhpunitWithClassAttributeTest.php
+++ b/tests/Functional/PhpunitWithClassAttributeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Functional;
+
+use DAMA\DoctrineTestBundle\PHPUnit\SkipStaticDatabaseConnection;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\TestCase;
+use Tests\Functional\FunctionalTestTrait;
+
+#[SkipStaticDatabaseConnection]
+class PhpunitWithClassAttributeTest extends TestCase
+{
+    use FunctionalTestTrait;
+
+    public function testTransactionalBehaviorDisabledWithAttributeOnClassLevel(): void
+    {
+        $this->insertRow();
+        $this->assertRowCount(1);
+    }
+
+    #[Depends('testTransactionalBehaviorDisabledWithAttributeOnClassLevel')]
+    public function testChangesFromPreviousTestAreVisibleWhenDisabledWithAttributeOnClassLevel(): void
+    {
+        $this->assertRowCount(1);
+
+        // cleanup persisted row to not affect any other tests afterwards
+        $this->connection->executeQuery('DELETE FROM test');
+    }
+}


### PR DESCRIPTION
Allows to skip the transactional database connection logic for individual tests by adding `#[SkipStaticDatabaseConnection]` to a test class or method. 

Closes #182 

Todos:
- [x] test on real app(s)
- [ ] is `SkipStaticDatabaseConnection` a good name for the attribute?
- [x] add to readme