### PR TITLE
rename attribute to `SkipDatabaseRollback`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ doctrine:
 
 ##### Skipping the transactional database connection handling for specific tests
 
-With PHPUnit you can skip this bundle's transactional database connection handling for specific tests if needed:
+With PHPUnit you can skip this bundle's database rollback handling for specific tests if needed:
 
 ```php
-#[SkipStaticDatabaseConnection] // this will skip it for all tests in a class
+#[SkipDatabaseRollback] // this will skip it for all tests in a class
 public class MyTest extends \PHPUnit\Framework\TestCase {}
 
-#[SkipStaticDatabaseConnection] // this will skip it for only one test method
+#[SkipDatabaseRollback] // this will skip it for only one test method
 public function MyTest() {}
 ```
 

--- a/src/PHPUnit/PHPUnitExtension.php
+++ b/src/PHPUnit/PHPUnitExtension.php
@@ -89,12 +89,12 @@ class PHPUnitExtension implements Extension
         }
 
         $reflectionClass = new \ReflectionClass($test->className());
-        if ($reflectionClass->getAttributes(SkipStaticDatabaseConnection::class)) {
+        if ($reflectionClass->getAttributes(SkipDatabaseRollback::class)) {
             return true;
         }
 
         return $reflectionClass->hasMethod($methodName = $test->methodName())
-            && $reflectionClass->getMethod($methodName)->getAttributes(SkipStaticDatabaseConnection::class);
+            && $reflectionClass->getMethod($methodName)->getAttributes(SkipDatabaseRollback::class);
     }
 
     public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void

--- a/src/PHPUnit/SkipDatabaseRollback.php
+++ b/src/PHPUnit/SkipDatabaseRollback.php
@@ -5,6 +5,6 @@ declare(strict_types=1);
 namespace DAMA\DoctrineTestBundle\PHPUnit;
 
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
-final class SkipStaticDatabaseConnection
+final class SkipDatabaseRollback
 {
 }

--- a/tests/Functional/PhpunitTest.php
+++ b/tests/Functional/PhpunitTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Functional;
 
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
-use DAMA\DoctrineTestBundle\PHPUnit\SkipStaticDatabaseConnection;
+use DAMA\DoctrineTestBundle\PHPUnit\SkipDatabaseRollback;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use PHPUnit\Event\Test\BeforeTestMethodErroredSubscriber;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -207,14 +207,14 @@ class PhpunitTest extends TestCase
         StaticDriver::setKeepStaticConnections(true);
     }
 
-    #[SkipStaticDatabaseConnection]
+    #[SkipDatabaseRollback]
     public function testTransactionalBehaviorDisabledWithAttribute(): void
     {
         $this->insertRow();
         $this->assertRowCount(1);
     }
 
-    #[SkipStaticDatabaseConnection]
+    #[SkipDatabaseRollback]
     #[Depends('testTransactionalBehaviorDisabledWithAttribute')]
     public function testChangesFromPreviousTestAreVisibleWhenDisabledWithAttribute(): void
     {

--- a/tests/Functional/PhpunitWithClassAttributeTest.php
+++ b/tests/Functional/PhpunitWithClassAttributeTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Functional;
 
-use DAMA\DoctrineTestBundle\PHPUnit\SkipStaticDatabaseConnection;
+use DAMA\DoctrineTestBundle\PHPUnit\SkipDatabaseRollback;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Tests\Functional\FunctionalTestTrait;
 
-#[SkipStaticDatabaseConnection]
+#[SkipDatabaseRollback]
 class PhpunitWithClassAttributeTest extends TestCase
 {
     use FunctionalTestTrait;


### PR DESCRIPTION
Follow up for https://github.com/dmaicher/doctrine-test-bundle/pull/339 to rename the attribute.

Its a BC break but I doubt the attribute was adopted already. 